### PR TITLE
Factor Out First Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ all: $(binary)
 release: CPPFLAGS += -DG_DISABLE_ASSERT -DNDEBUG
 release: $(binary)
 
-$(binary): src/terminal-config.h src/stulto-application.h src/stulto-application.c src/stulto.c
+$(binary): src/terminal-config.h \
+           src/exit-status.h src/exit-status.c \
+           src/stulto-terminal.h src/stulto-terminal.c \
+           src/stulto-application.h src/stulto-application.c \
+           src/stulto.c
 	$E '  CC/LD   $@'
 	$Q$(CC) $(CFLAGS) $(CPPFLAGS) $^ -o $@ $(LDFLAGS) $(LIBS)
 

--- a/src/exit-status.c
+++ b/src/exit-status.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "exit-status.h"
+
+int exit_status = EXIT_FAILURE;
+
+int stulto_get_exit_status() {
+    return exit_status;
+}
+
+void stulto_set_exit_status(int status) {
+    exit_status = status;
+}
+
+void destroy_and_quit(GtkWidget *window) {
+    gtk_widget_destroy(window);
+
+    gtk_main_quit();
+}

--- a/src/exit-status.h
+++ b/src/exit-status.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * Exit status as an app state variable is a concept inherited from the stupidterm codebase
+ * We'll remove this module once we refactor Stulto to depend on GtkApplication's lifecycle management
+ */
+
+#ifndef EXIT_STATUS_H
+#define EXIT_STATUS_H
+
+#include <gtk/gtk.h>
+
+int stulto_get_exit_status();
+
+void stulto_set_exit_status(int status);
+
+/*
+ * This isn't exactly the right place for this function, but as it's currently used in two modules and isn't worth
+ * adding another, we'll live with the loose fit until _this_ module is refactored away
+ */
+void destroy_and_quit(GtkWidget *window);
+
+#endif //EXIT_STATUS_H

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -21,27 +21,17 @@
 
 #include <stdlib.h>
 
-#include "terminal-config.h"
 #include "stulto-application.h"
+
+#include "exit-status.h"
+#include "terminal-config.h"
+#include "stulto-terminal.h"
 
 typedef struct _StultoApplication {
     GtkWindow *window;
     GtkNotebook *notebook;
     StultoTerminalConfig *conf;
 } StultoApplication;
-
-// This is inherited from the stupidterm code base
-// In general, I don't like using free-hanging constants to track application state like this, but we'll live with it
-// until we migrate to GObject
-int exit_status = EXIT_FAILURE;
-
-int stulto_get_exit_status();
-
-// Declare the terminal creator early so we don't have to shuffle around code just to keep the new-tab keybinding from
-// breaking
-// TODO - the real fix is to not host every.single.function in one file - this project is big enough to justify a more
-// granular architecture
-static GtkWidget *create_terminal(StultoApplication *app);
 
 static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer data) {
     GdkScreen *screen = gtk_widget_get_screen(widget);
@@ -58,121 +48,10 @@ static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer da
     gtk_widget_set_visual(widget, visual);
 }
 
-static void window_title_changed(GtkWidget *widget, gpointer data) {
-    GtkWindow *window = data;
-
-    GtkWidget *notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
-
-    gint num_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
-    gint cur_tab = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-    gchar *new_title = g_strdup_printf(
-            "[%d/%d] %s",
-            cur_tab + 1,
-            num_tabs,
-            vte_terminal_get_window_title(VTE_TERMINAL(widget)));
-
-    gtk_window_set_title(window, new_title);
-}
-
-static void handle_bell(GtkWidget *widget, gpointer data) {
-    GtkWindow *window = data;
-
-    gtk_window_set_urgency_hint(window, TRUE);
-}
-
-static int handle_focus_in(GtkWidget *widget, GdkEvent *event, gpointer data) {
-    GtkWindow *window = data;
-
-    gtk_window_set_urgency_hint(window, FALSE);
-
-    return FALSE;
-}
-
-static void destroy_and_quit(GtkWidget *window) {
-    gtk_widget_destroy(window);
-
-    gtk_main_quit();
-}
-
 static void delete_event(GtkWidget *window, GdkEvent *event, gpointer data) {
-    exit_status = EXIT_SUCCESS;
+    stulto_set_exit_status(EXIT_SUCCESS);
 
     destroy_and_quit(window);
-}
-
-static void child_exited(VteTerminal *widget, int status, gpointer data) {
-    StultoApplication *app = data;
-
-    gint numPages = gtk_notebook_get_n_pages(app->notebook);
-    gint currentPage = gtk_notebook_get_current_page(app->notebook);
-
-    if (numPages > 1) {
-        gtk_notebook_remove_page(app->notebook, currentPage);
-        return;
-    }
-
-    exit_status = status;
-    destroy_and_quit(GTK_WIDGET(app->window));
-}
-
-static gboolean button_press_event(GtkWidget *widget, GdkEvent *event, gpointer data) {
-    gchar *program = data;
-
-    char *match;
-    int tag;
-
-    if (event->button.button != 3) {
-        return FALSE;
-    }
-
-    match = vte_terminal_match_check_event(VTE_TERMINAL(widget), event, &tag);
-    if (match != NULL) {
-        GError *error = NULL;
-        gchar *argv[3] = {program, match, NULL};
-
-        if (!g_spawn_async(NULL, argv, NULL,
-                           G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL,
-                           NULL, NULL, NULL, &error)) {
-            g_printerr("%s\n", error->message);
-            g_error_free(error);
-        }
-        g_free(match);
-    }
-
-    return FALSE;
-}
-
-static void resize_window(GtkWidget *widget, guint width, guint height, gpointer data) {
-    GtkWindow *window = data;
-
-    VteTerminal *terminal = VTE_TERMINAL(widget);
-    glong row_count = vte_terminal_get_row_count(terminal);
-    glong column_count = vte_terminal_get_column_count(terminal);
-    glong char_width = vte_terminal_get_char_width(terminal);
-    glong char_height = vte_terminal_get_char_height(terminal);
-    gint owidth;
-    gint oheight;
-    GtkBorder padding;
-
-    if (width < 2) {
-        width = 2;
-    }
-    if (height < 2) {
-        height = 2;
-    }
-
-    gtk_window_get_size(window, &owidth, &oheight);
-
-    /* Take into account border overhead. */
-    gtk_style_context_get_padding(
-            gtk_widget_get_style_context(widget),
-            gtk_widget_get_state_flags(widget),
-            &padding);
-
-    owidth -= char_width * column_count + padding.left + padding.right;
-    oheight -= char_height * row_count + padding.top + padding.bottom;
-    gtk_window_resize(GTK_WINDOW(data),
-                      width + owidth, height + oheight);
 }
 
 static void page_added(GtkNotebook *notebook, GtkWidget *child, guint page_num, gpointer data) {
@@ -199,100 +78,7 @@ static void switch_page(GtkNotebook *notebook, GtkWidget *child, guint page_num,
             vte_terminal_get_window_title(VTE_TERMINAL(child)));
 
     gtk_window_set_title(GTK_WINDOW(window), new_title);
-}
-
-static void adjust_font_size(GtkWidget *widget, GtkWindow *window, gdouble factor) {
-    VteTerminal *terminal = VTE_TERMINAL(widget);
-    glong rows = vte_terminal_get_row_count(terminal);
-    glong columns = vte_terminal_get_column_count(terminal);
-    glong char_width = vte_terminal_get_char_width(terminal);
-    glong char_height = vte_terminal_get_char_height(terminal);
-    gint owidth;
-    gint oheight;
-    gdouble scale;
-
-    /* Take into account padding and border overhead. */
-    gtk_window_get_size(window, &owidth, &oheight);
-    owidth -= char_width * columns;
-    oheight -= char_height * rows;
-
-    scale = vte_terminal_get_font_scale(terminal);
-    vte_terminal_set_font_scale(terminal, scale * factor);
-
-    /* This above call will have changed the char size! */
-    char_width = vte_terminal_get_char_width(terminal);
-    char_height = vte_terminal_get_char_height(terminal);
-
-    gtk_window_resize(
-            window,
-            columns * char_width + owidth,
-            rows * char_height + oheight);
-}
-
-static void increase_font_size(GtkWidget *widget, gpointer data) {
-    GtkWindow *window = data;
-
-    adjust_font_size(widget, window, 1.125);
-}
-
-static void decrease_font_size(GtkWidget *widget, gpointer data) {
-    GtkWindow *window = data;
-
-    adjust_font_size(widget, window, 1. / 1.125);
-}
-
-static gboolean key_press_event(GtkWidget *widget, GdkEvent *event, gpointer data) {
-    StultoApplication *app = data;
-    GtkWidget *window = GTK_WIDGET(app->window);
-
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-
-    g_assert(event->type == GDK_KEY_PRESS);
-
-    if ((event->key.state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
-        switch (event->key.hardware_keycode) {
-            case 21: /* + on US keyboards */
-                increase_font_size(widget, window);
-                return TRUE;
-            case 20: /* - on US keyboards */
-                decrease_font_size(widget, window);
-                return TRUE;
-        }
-        switch (gdk_keyval_to_lower(event->key.keyval)) {
-            case GDK_KEY_c:
-                vte_terminal_copy_clipboard_format(
-                        (VteTerminal *) widget,
-                        VTE_FORMAT_TEXT);
-                return TRUE;
-            case GDK_KEY_v:
-                vte_terminal_paste_clipboard((VteTerminal *) widget);
-                return TRUE;
-            case GDK_KEY_t:
-                gtk_notebook_append_page(app->notebook, create_terminal(data), gtk_label_new("New Tab"));
-                return TRUE;
-        }
-    }
-
-    if ((event->key.state & modifiers) == (GDK_CONTROL_MASK)) {
-        switch (gdk_keyval_to_lower(event->key.keyval)) {
-            case GDK_KEY_Page_Up:
-                gtk_notebook_prev_page(GTK_NOTEBOOK(app->notebook));
-                return TRUE;
-            case GDK_KEY_Page_Down:
-                gtk_notebook_next_page(GTK_NOTEBOOK(app->notebook));
-                return TRUE;
-        }
-    }
-
-    return FALSE;
-}
-
-static gboolean selection_changed(VteTerminal *terminal, gpointer data) {
-    if (vte_terminal_get_has_selection(terminal)) {
-        vte_terminal_copy_clipboard_format(terminal, VTE_FORMAT_TEXT);
-    }
-
-    return TRUE;
+    g_free(new_title);
 }
 
 static gboolean parse_color(GKeyFile *file, const gchar *filename, const gchar *key, gboolean required, GdkRGBA *out) {
@@ -493,146 +279,6 @@ static void parse_file(StultoTerminalConfig *conf, GOptionEntry *options) {
     g_free(filename);
 }
 
-static void connect_terminal_signals(VteTerminal *terminal, StultoApplication *app) {
-    GtkWidget *widget = GTK_WIDGET(terminal);
-    GtkWidget *window = GTK_WIDGET(app->window);
-    StultoTerminalConfig *conf = app->conf;
-
-    /* Connect to the "window-title-changed" signal to set the main window's title */
-    g_signal_connect(widget, "window-title-changed", G_CALLBACK(window_title_changed), window);
-
-    /* Connect to the "button-press" event. */
-    if (conf->program)
-        g_signal_connect(widget, "button-press-event", G_CALLBACK(button_press_event), conf->program);
-
-    /* Connect to application request signals. */
-    g_signal_connect(widget, "resize-window", G_CALLBACK(resize_window), window);
-
-    /* Connect to font tweakage */
-    g_signal_connect(widget, "increase-font-size", G_CALLBACK(increase_font_size), window);
-    g_signal_connect(widget, "decrease-font-size", G_CALLBACK(decrease_font_size), window);
-    g_signal_connect(widget, "key-press-event", G_CALLBACK(key_press_event), app);
-
-    /* Connect to bell signal */
-    if (conf->urgent_on_bell) {
-        g_signal_connect(widget, "bell", G_CALLBACK(handle_bell), window);
-        g_signal_connect(widget, "focus-in-event", G_CALLBACK(handle_focus_in), window);
-    }
-
-    /* Sync clipboard */
-    if (conf->sync_clipboard)
-        g_signal_connect(widget, "selection-changed", G_CALLBACK(selection_changed), NULL);
-}
-
-static void configure_terminal(VteTerminal *terminal, StultoTerminalConfig *conf) {
-    /* Set some defaults. */
-    vte_terminal_set_scroll_on_output(terminal, conf->scroll_on_output);
-    vte_terminal_set_scroll_on_keystroke(terminal, conf->scroll_on_keystroke);
-    vte_terminal_set_mouse_autohide(terminal, conf->mouse_autohide);
-    vte_terminal_set_cursor_blink_mode(terminal, VTE_CURSOR_BLINK_OFF);
-    vte_terminal_set_cursor_shape(terminal, VTE_CURSOR_SHAPE_BLOCK);
-    vte_terminal_set_bold_is_bright(terminal, TRUE);
-    if (conf->lines) {
-        vte_terminal_set_scrollback_lines(terminal, conf->lines);
-    }
-    if (conf->palette_size) {
-        vte_terminal_set_colors(terminal, &conf->foreground, &conf->background, conf->palette, conf->palette_size - 2);
-    }
-    if (conf->highlight.alpha) {
-        vte_terminal_set_color_highlight(terminal, &conf->highlight);
-    }
-    if (conf->highlight_fg.alpha) {
-        vte_terminal_set_color_highlight_foreground(terminal, &conf->highlight_fg);
-    }
-    if (conf->font) {
-        PangoFontDescription *desc = pango_font_description_from_string(conf->font);
-
-        vte_terminal_set_font(terminal, desc);
-        pango_font_description_free(desc);
-    }
-    if (conf->regex) {
-#ifdef VTE_TYPE_REGEX
-        int id = vte_terminal_match_add_regex(terminal, conf->regex, 0);
-#else
-        int id = vte_terminal_match_add_gregex(terminal, conf->regex, 0);
-        g_regex_unref(conf->regex);
-#endif
-        vte_terminal_match_set_cursor_name(terminal, id, "pointer");
-    }
-}
-
-static void get_shell_and_title(VteTerminal *terminal, StultoTerminalConfig *conf, GtkWidget *window) {
-    // TODO - eventually we want to split these out and configure the ability to customize the window title
-    if (conf->command_argv == NULL || conf->command_argv[0] == NULL) {
-        g_strfreev(conf->command_argv);
-        conf->command_argv = g_malloc(2 * sizeof(gchar *));
-        conf->command_argv[0] = vte_get_user_shell();
-        conf->command_argv[1] = NULL;
-
-        if (conf->command_argv[0] == NULL || conf->command_argv[0][0] == '\0') {
-            const gchar *shell = g_getenv("SHELL");
-
-            if (shell == NULL || shell[0] == '\0') {
-                shell = "/bin/sh";
-            }
-
-            g_free(conf->command_argv[0]);
-            conf->command_argv[0] = g_strdup(shell);
-        }
-    } else {
-        gchar *title = g_strjoinv(" ", conf->command_argv);
-
-        gtk_window_set_title(GTK_WINDOW(window), title);
-        g_free(title);
-    }
-}
-
-static void spawn_callback(VteTerminal *terminal, GPid pid, GError *error, gpointer data) {
-    StultoApplication *app = data;
-    GtkWidget *widget = GTK_WIDGET(terminal);
-    GtkWidget *window = GTK_WIDGET(app->window);
-
-    if (pid < 0) {
-        g_printerr("%s\n", error->message);
-        g_error_free(error);
-        destroy_and_quit(window);
-
-        return;
-    }
-
-    g_signal_connect(widget, "child-exited", G_CALLBACK(child_exited), app);
-
-    gtk_widget_realize(widget);
-}
-
-static GtkWidget *create_terminal(StultoApplication *app) {
-    GtkWidget *window_widget = GTK_WIDGET(app->window);
-
-    GtkWidget *terminal_widget = vte_terminal_new();
-    VteTerminal *terminal = VTE_TERMINAL(terminal_widget);
-
-    connect_terminal_signals(terminal, app);
-    configure_terminal(terminal, app->conf);
-    get_shell_and_title(terminal, app->conf, window_widget);
-
-    vte_terminal_spawn_async(
-            terminal,
-            VTE_PTY_DEFAULT,
-            NULL,
-            app->conf->command_argv,
-            NULL,
-            G_SPAWN_SEARCH_PATH,
-            NULL,
-            NULL,
-            NULL,
-            -1,
-            NULL,
-            &spawn_callback,
-            (gpointer) app);
-
-    return terminal_widget;
-}
-
 gboolean stulto_application_init(int argc, char *argv[]) {
     StultoTerminalConfig *conf = g_malloc(sizeof(StultoTerminalConfig));
     GOptionEntry options[] = {
@@ -763,7 +409,7 @@ gboolean stulto_application_init(int argc, char *argv[]) {
     g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
 
     // For whatever odd reason, the first terminal created, doesn't capture focus automatically
-    GtkWidget *term = create_terminal(app);
+    GtkWidget *term = create_terminal(conf);
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook), term, NULL);
 
@@ -772,8 +418,4 @@ gboolean stulto_application_init(int argc, char *argv[]) {
     gtk_widget_show_all(window);
 
     return TRUE;
-}
-
-int stulto_get_exit_status() {
-    return exit_status;
 }

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -27,12 +27,6 @@
 #include "terminal-config.h"
 #include "stulto-terminal.h"
 
-typedef struct _StultoApplication {
-    GtkWindow *window;
-    GtkNotebook *notebook;
-    StultoTerminalConfig *conf;
-} StultoApplication;
-
 static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer data) {
     GdkScreen *screen = gtk_widget_get_screen(widget);
     GdkVisual *visual = NULL;
@@ -399,11 +393,6 @@ gboolean stulto_application_init(int argc, char *argv[]) {
     gtk_notebook_set_show_tabs(GTK_NOTEBOOK(notebook), FALSE);
     gtk_notebook_set_scrollable(GTK_NOTEBOOK(notebook), TRUE);
     gtk_container_add(GTK_CONTAINER(window), notebook);
-
-    StultoApplication *app = g_malloc(sizeof(StultoApplication));
-    app->window = GTK_WINDOW(window);
-    app->notebook = GTK_NOTEBOOK(notebook);
-    app->conf = conf;
 
     g_signal_connect(notebook, "page-added", G_CALLBACK(page_added), conf);
     g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);

--- a/src/stulto-application.h
+++ b/src/stulto-application.h
@@ -1,6 +1,21 @@
-//
-// Created by marcxjo on 9/28/22.
-//
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
 
 #ifndef APPLICATION_H
 #define APPLICATION_H

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -1,0 +1,354 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "stulto-terminal.h"
+
+#include "exit-status.h"
+
+static void window_title_changed(GtkWidget *widget, gpointer data) {
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+    GtkWidget *notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
+
+    gint num_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
+    gint cur_tab = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
+    gchar *new_title = g_strdup_printf(
+            "[%d/%d] %s",
+            cur_tab + 1,
+            num_tabs,
+            vte_terminal_get_window_title(VTE_TERMINAL(widget)));
+
+    gtk_window_set_title(GTK_WINDOW(window), new_title);
+    g_free(new_title);
+}
+
+static void handle_bell(GtkWidget *widget, gpointer data) {
+    GtkWindow *window = data;
+
+    gtk_window_set_urgency_hint(window, TRUE);
+}
+
+static int handle_focus_in(GtkWidget *widget, GdkEvent *event, gpointer data) {
+    GtkWindow *window = data;
+
+    gtk_window_set_urgency_hint(window, FALSE);
+
+    return FALSE;
+}
+
+static void child_exited(VteTerminal *widget, int status, gpointer data) {
+    GtkWidget *window = gtk_widget_get_ancestor(GTK_WIDGET(widget), GTK_TYPE_WINDOW);
+    GtkWidget *notebook = gtk_widget_get_ancestor(GTK_WIDGET(widget), GTK_TYPE_NOTEBOOK);
+
+    gint numPages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
+    gint currentPage = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
+
+    if (numPages > 1) {
+        gtk_notebook_remove_page(GTK_NOTEBOOK(notebook), currentPage);
+        return;
+    }
+
+    stulto_set_exit_status(status);
+    destroy_and_quit(window);
+}
+
+static gboolean button_press_event(GtkWidget *widget, GdkEvent *event, gpointer data) {
+    gchar *program = data;
+
+    char *match;
+    int tag;
+
+    if (event->button.button != 3) {
+        return FALSE;
+    }
+
+    match = vte_terminal_match_check_event(VTE_TERMINAL(widget), event, &tag);
+    if (match != NULL) {
+        GError *error = NULL;
+        gchar *argv[3] = {program, match, NULL};
+
+        if (!g_spawn_async(NULL, argv, NULL,
+                           G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL,
+                           NULL, NULL, NULL, &error)) {
+            g_printerr("%s\n", error->message);
+            g_error_free(error);
+        }
+        g_free(match);
+    }
+
+    return FALSE;
+}
+
+static void resize_window(GtkWidget *widget, guint width, guint height, gpointer data) {
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+    VteTerminal *terminal = VTE_TERMINAL(widget);
+
+    glong row_count = vte_terminal_get_row_count(terminal);
+    glong column_count = vte_terminal_get_column_count(terminal);
+    glong char_width = vte_terminal_get_char_width(terminal);
+    glong char_height = vte_terminal_get_char_height(terminal);
+    gint owidth;
+    gint oheight;
+    GtkBorder padding;
+
+    if (width < 2) {
+        width = 2;
+    }
+    if (height < 2) {
+        height = 2;
+    }
+
+    gtk_window_get_size(GTK_WINDOW(window), &owidth, &oheight);
+
+    /* Take into account border overhead. */
+    gtk_style_context_get_padding(
+            gtk_widget_get_style_context(widget),
+            gtk_widget_get_state_flags(widget),
+            &padding);
+
+    owidth -= char_width * column_count + padding.left + padding.right;
+    oheight -= char_height * row_count + padding.top + padding.bottom;
+    gtk_window_resize(GTK_WINDOW(data),
+                      width + owidth, height + oheight);
+}
+
+static void adjust_font_size(GtkWidget *widget, GtkWindow *window, gdouble factor) {
+    VteTerminal *terminal = VTE_TERMINAL(widget);
+    glong rows = vte_terminal_get_row_count(terminal);
+    glong columns = vte_terminal_get_column_count(terminal);
+    glong char_width = vte_terminal_get_char_width(terminal);
+    glong char_height = vte_terminal_get_char_height(terminal);
+    gint owidth;
+    gint oheight;
+    gdouble scale;
+
+    /* Take into account padding and border overhead. */
+    gtk_window_get_size(window, &owidth, &oheight);
+    owidth -= char_width * columns;
+    oheight -= char_height * rows;
+
+    scale = vte_terminal_get_font_scale(terminal);
+    vte_terminal_set_font_scale(terminal, scale * factor);
+
+    /* This above call will have changed the char size! */
+    char_width = vte_terminal_get_char_width(terminal);
+    char_height = vte_terminal_get_char_height(terminal);
+
+    gtk_window_resize(
+            window,
+            columns * char_width + owidth,
+            rows * char_height + oheight);
+}
+
+static void increase_font_size(GtkWidget *widget, gpointer data) {
+    GtkWindow *window = data;
+
+    adjust_font_size(widget, window, 1.125);
+}
+
+static void decrease_font_size(GtkWidget *widget, gpointer data) {
+    GtkWindow *window = data;
+
+    adjust_font_size(widget, window, 1. / 1.125);
+}
+
+static gboolean key_press_event(GtkWidget *widget, GdkEvent *event, gpointer data) {
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+    GtkWidget *notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
+
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+
+    g_assert(event->type == GDK_KEY_PRESS);
+
+    if ((event->key.state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+        switch (event->key.hardware_keycode) {
+            case 21: /* + on US keyboards */
+                increase_font_size(widget, window);
+                return TRUE;
+            case 20: /* - on US keyboards */
+                decrease_font_size(widget, window);
+                return TRUE;
+        }
+        switch (gdk_keyval_to_lower(event->key.keyval)) {
+            case GDK_KEY_c:
+                vte_terminal_copy_clipboard_format(
+                        (VteTerminal *) widget,
+                        VTE_FORMAT_TEXT);
+                return TRUE;
+            case GDK_KEY_v:
+                vte_terminal_paste_clipboard((VteTerminal *) widget);
+                return TRUE;
+            case GDK_KEY_t:
+                gtk_notebook_append_page(GTK_NOTEBOOK(notebook), create_terminal(data), gtk_label_new("New Tab"));
+                return TRUE;
+        }
+    }
+
+    if ((event->key.state & modifiers) == (GDK_CONTROL_MASK)) {
+        switch (gdk_keyval_to_lower(event->key.keyval)) {
+            case GDK_KEY_Page_Up:
+                gtk_notebook_prev_page(GTK_NOTEBOOK(notebook));
+                return TRUE;
+            case GDK_KEY_Page_Down:
+                gtk_notebook_next_page(GTK_NOTEBOOK(notebook));
+                return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+static gboolean selection_changed(VteTerminal *terminal, gpointer data) {
+    if (vte_terminal_get_has_selection(terminal)) {
+        vte_terminal_copy_clipboard_format(terminal, VTE_FORMAT_TEXT);
+    }
+
+    return TRUE;
+}
+
+static void connect_terminal_signals(VteTerminal *terminal, StultoTerminalConfig *conf) {
+    GtkWidget *widget = GTK_WIDGET(terminal);
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+
+    /* Connect to the "window-title-changed" signal to set the main window's title */
+    g_signal_connect(widget, "window-title-changed", G_CALLBACK(window_title_changed), NULL);
+
+    /* Connect to the "button-press" event. */
+    if (conf->program)
+        g_signal_connect(widget, "button-press-event", G_CALLBACK(button_press_event), conf->program);
+
+    /* Connect to application request signals. */
+    g_signal_connect(widget, "resize-window", G_CALLBACK(resize_window), window);
+
+    /* Connect to font tweakage */
+    g_signal_connect(widget, "increase-font-size", G_CALLBACK(increase_font_size), window);
+    g_signal_connect(widget, "decrease-font-size", G_CALLBACK(decrease_font_size), window);
+    g_signal_connect(widget, "key-press-event", G_CALLBACK(key_press_event), conf);
+
+    /* Connect to bell signal */
+    if (conf->urgent_on_bell) {
+        g_signal_connect(widget, "bell", G_CALLBACK(handle_bell), window);
+        g_signal_connect(widget, "focus-in-event", G_CALLBACK(handle_focus_in), window);
+    }
+
+    /* Sync clipboard */
+    if (conf->sync_clipboard)
+        g_signal_connect(widget, "selection-changed", G_CALLBACK(selection_changed), NULL);
+}
+
+static void configure_terminal(VteTerminal *terminal, StultoTerminalConfig *conf) {
+    /* Set some defaults. */
+    vte_terminal_set_scroll_on_output(terminal, conf->scroll_on_output);
+    vte_terminal_set_scroll_on_keystroke(terminal, conf->scroll_on_keystroke);
+    vte_terminal_set_mouse_autohide(terminal, conf->mouse_autohide);
+    vte_terminal_set_cursor_blink_mode(terminal, VTE_CURSOR_BLINK_OFF);
+    vte_terminal_set_cursor_shape(terminal, VTE_CURSOR_SHAPE_BLOCK);
+    vte_terminal_set_bold_is_bright(terminal, TRUE);
+    if (conf->lines) {
+        vte_terminal_set_scrollback_lines(terminal, conf->lines);
+    }
+    if (conf->palette_size) {
+        vte_terminal_set_colors(terminal, &conf->foreground, &conf->background, conf->palette, conf->palette_size - 2);
+    }
+    if (conf->highlight.alpha) {
+        vte_terminal_set_color_highlight(terminal, &conf->highlight);
+    }
+    if (conf->highlight_fg.alpha) {
+        vte_terminal_set_color_highlight_foreground(terminal, &conf->highlight_fg);
+    }
+    if (conf->font) {
+        PangoFontDescription *desc = pango_font_description_from_string(conf->font);
+
+        vte_terminal_set_font(terminal, desc);
+        pango_font_description_free(desc);
+    }
+    if (conf->regex) {
+#ifdef VTE_TYPE_REGEX
+        int id = vte_terminal_match_add_regex(terminal, conf->regex, 0);
+#else
+        int id = vte_terminal_match_add_gregex(terminal, conf->regex, 0);
+        g_regex_unref(conf->regex);
+#endif
+        vte_terminal_match_set_cursor_name(terminal, id, "pointer");
+    }
+}
+
+static void get_shell_and_title(VteTerminal *terminal, StultoTerminalConfig *conf) {
+    // TODO - eventually we want to split these out and configure the ability to customize the window title
+    if (conf->command_argv == NULL || conf->command_argv[0] == NULL) {
+        g_strfreev(conf->command_argv);
+        conf->command_argv = g_malloc(2 * sizeof(gchar *));
+        conf->command_argv[0] = vte_get_user_shell();
+        conf->command_argv[1] = NULL;
+
+        if (conf->command_argv[0] == NULL || conf->command_argv[0][0] == '\0') {
+            const gchar *shell = g_getenv("SHELL");
+
+            if (shell == NULL || shell[0] == '\0') {
+                shell = "/bin/sh";
+            }
+
+            g_free(conf->command_argv[0]);
+            conf->command_argv[0] = g_strdup(shell);
+        }
+    }
+}
+
+static void spawn_callback(VteTerminal *terminal, GPid pid, GError *error, gpointer data) {
+    GtkWidget *widget = GTK_WIDGET(terminal);
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+
+    if (pid < 0) {
+        g_printerr("%s\n", error->message);
+        g_error_free(error);
+        destroy_and_quit(window);
+
+        return;
+    }
+
+    g_signal_connect(widget, "child-exited", G_CALLBACK(child_exited), NULL);
+
+    gtk_widget_realize(widget);
+}
+
+GtkWidget *create_terminal(StultoTerminalConfig *conf) {
+    GtkWidget *terminal_widget = vte_terminal_new();
+
+    VteTerminal *terminal = VTE_TERMINAL(terminal_widget);
+
+    connect_terminal_signals(terminal, conf);
+    configure_terminal(terminal, conf);
+    get_shell_and_title(terminal, conf);
+
+    vte_terminal_spawn_async(
+            terminal,
+            VTE_PTY_DEFAULT,
+            NULL,
+            conf->command_argv,
+            NULL,
+            G_SPAWN_SEARCH_PATH,
+            NULL,
+            NULL,
+            NULL,
+            -1,
+            NULL,
+            &spawn_callback,
+            NULL);
+
+    return terminal_widget;
+}

--- a/src/stulto-terminal.h
+++ b/src/stulto-terminal.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef STULTO_TERMINAL_H
+#define STULTO_TERMINAL_H
+
+#include <gtk/gtk.h>
+
+#include "terminal-config.h"
+
+GtkWidget *create_terminal(StultoTerminalConfig *conf);
+
+#endif //STULTO_TERMINAL_H

--- a/src/stulto.c
+++ b/src/stulto.c
@@ -22,6 +22,7 @@
 #include <vte/vte.h>
 
 #include "stulto-application.h"
+#include "exit-status.h"
 
 int main(int argc, char *argv[]) {
     if (stulto_application_init(argc, argv)) {

--- a/src/terminal-config.h
+++ b/src/terminal-config.h
@@ -1,6 +1,21 @@
-//
-// Created by marcxjo on 9/25/22.
-//
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
 
 #ifndef TERMINAL_CONFIG_H
 #define TERMINAL_CONFIG_H


### PR DESCRIPTION
This is another intermediate step in the move to GObject. It factors out:

* The terminal creation/config logic
* The exit status handling
  * This ultimately needs to go away - when we move to GtkApplication, we should be able to remove it, but for simplicity, I've just left it intact but isolated

There will probably need to be a few more merges like this to pull out, e.g., the `GtkNotebook` and the config parsing logic, before the GObject refactor can begin in earnest. Hard to tell whether we'll also want to plug in certain features (e.g., config per terminal screen) sooner or later.