### PR TITLE
Standardize Public Function Nomenclature

### DIFF
--- a/src/exit-status.c
+++ b/src/exit-status.c
@@ -29,7 +29,7 @@ void stulto_set_exit_status(int status) {
     exit_status = status;
 }
 
-void destroy_and_quit(GtkWidget *window) {
+void stulto_destroy_and_quit(GtkWidget *window) {
     gtk_widget_destroy(window);
 
     gtk_main_quit();

--- a/src/exit-status.h
+++ b/src/exit-status.h
@@ -35,6 +35,6 @@ void stulto_set_exit_status(int status);
  * This isn't exactly the right place for this function, but as it's currently used in two modules and isn't worth
  * adding another, we'll live with the loose fit until _this_ module is refactored away
  */
-void destroy_and_quit(GtkWidget *window);
+void stulto_destroy_and_quit(GtkWidget *window);
 
 #endif //EXIT_STATUS_H

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -127,7 +127,7 @@ static void parse_options(GOptionEntry *options, GKeyFile *file, gchar *filename
     }
 }
 
-gboolean stulto_application_init(int argc, char *argv[]) {
+gboolean stulto_application_create(int argc, char *argv[]) {
     StultoTerminalConfig *conf = g_malloc(sizeof(StultoTerminalConfig));
 
     // TODO - when we refactor to GtkApplication, most of these options will go away

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -283,7 +283,7 @@ gboolean stulto_application_init(int argc, char *argv[]) {
     g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
 
     // For whatever odd reason, the first terminal created, doesn't capture focus automatically
-    GtkWidget *term = create_terminal(conf);
+    GtkWidget *term = stulto_terminal_create(conf);
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook), term, NULL);
 

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -45,7 +45,7 @@ static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer da
 static void delete_event(GtkWidget *window, GdkEvent *event, gpointer data) {
     stulto_set_exit_status(EXIT_SUCCESS);
 
-    destroy_and_quit(window);
+    stulto_destroy_and_quit(window);
 }
 
 static void page_added(GtkNotebook *notebook, GtkWidget *child, guint page_num, gpointer data) {

--- a/src/stulto-application.h
+++ b/src/stulto-application.h
@@ -22,7 +22,7 @@
 
 #include <glib.h>
 
-gboolean stulto_application_init(int argc, char *argv[]);
+gboolean stulto_application_create(int argc, char *argv[]);
 
 int stulto_get_exit_status();
 

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -64,7 +64,7 @@ static void child_exited(VteTerminal *widget, int status, gpointer data) {
     }
 
     stulto_set_exit_status(status);
-    destroy_and_quit(window);
+    stulto_destroy_and_quit(window);
 }
 
 static gboolean button_press_event(GtkWidget *widget, GdkEvent *event, gpointer data) {
@@ -316,7 +316,7 @@ static void spawn_callback(VteTerminal *terminal, GPid pid, GError *error, gpoin
     if (pid < 0) {
         g_printerr("%s\n", error->message);
         g_error_free(error);
-        destroy_and_quit(window);
+        stulto_destroy_and_quit(window);
 
         return;
     }

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -194,7 +194,7 @@ static gboolean key_press_event(GtkWidget *widget, GdkEvent *event, gpointer dat
                 vte_terminal_paste_clipboard((VteTerminal *) widget);
                 return TRUE;
             case GDK_KEY_t:
-                gtk_notebook_append_page(GTK_NOTEBOOK(notebook), create_terminal(data), gtk_label_new("New Tab"));
+                gtk_notebook_append_page(GTK_NOTEBOOK(notebook), stulto_terminal_create(data), gtk_label_new("New Tab"));
                 return TRUE;
         }
     }
@@ -326,7 +326,7 @@ static void spawn_callback(VteTerminal *terminal, GPid pid, GError *error, gpoin
     gtk_widget_realize(widget);
 }
 
-GtkWidget *create_terminal(StultoTerminalConfig *conf) {
+GtkWidget *stulto_terminal_create(StultoTerminalConfig *conf) {
     GtkWidget *terminal_widget = vte_terminal_new();
 
     VteTerminal *terminal = VTE_TERMINAL(terminal_widget);

--- a/src/stulto-terminal.h
+++ b/src/stulto-terminal.h
@@ -24,6 +24,6 @@
 
 #include "terminal-config.h"
 
-GtkWidget *create_terminal(StultoTerminalConfig *conf);
+GtkWidget *stulto_terminal_create(StultoTerminalConfig *conf);
 
 #endif //STULTO_TERMINAL_H

--- a/src/stulto.c
+++ b/src/stulto.c
@@ -25,7 +25,7 @@
 #include "exit-status.h"
 
 int main(int argc, char *argv[]) {
-    if (stulto_application_init(argc, argv)) {
+    if (stulto_application_create(argc, argv)) {
         gtk_main();
     }
 


### PR DESCRIPTION
Adds the `stulto` namespace to all publicly exposed functions and adopts GLib conventions without co-opting its terminology.

E.g., `stulto_thing_create` is preferred in place of `stulto_thing_new` or `stulto_thing_init` for non-OOP stulto types, since the latter forms co-opt GObject method naming conventions.

Not sure I'll regret this later if/when we refactor to GObject, but the hope is that the conventions implemented here will enable a more gradual migration.