### PR TITLE
Refactor Configuration Handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ all: $(binary)
 release: CPPFLAGS += -DG_DISABLE_ASSERT -DNDEBUG
 release: $(binary)
 
-$(binary): src/terminal-config.h src/terminal-config.c \
+$(binary): src/stulto-global-config.h \
+           src/terminal-config.h src/terminal-config.c \
            src/exit-status.h src/exit-status.c \
            src/stulto-headerbar.h src/stulto-headerbar.c \
            src/stulto-terminal.h src/stulto-terminal.c \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ all: $(binary)
 release: CPPFLAGS += -DG_DISABLE_ASSERT -DNDEBUG
 release: $(binary)
 
-$(binary): src/stulto-global-config.h \
+$(binary): src/stulto-app-config.h \
            src/terminal-config.h src/terminal-config.c \
            src/exit-status.h src/exit-status.c \
            src/stulto-headerbar.h src/stulto-headerbar.c \

--- a/src/stulto-app-config.h
+++ b/src/stulto-app-config.h
@@ -17,14 +17,14 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef STULTO_GLOBAL_CONFIG_H
-#define STULTO_GLOBAL_CONFIG_H
+#ifndef STULTO_APP_CONFIG_H
+#define STULTO_APP_CONFIG_H
 
 #include <glib.h>
 
-typedef struct _StultoGlobalConfig {
+typedef struct _StultoAppConfig {
     gchar *role;
     gboolean enable_headerbar;
-} StultoGlobalConfig;
+} StultoAppConfig;
 
-#endif //STULTO_GLOBAL_CONFIG_H
+#endif //STULTO_APP_CONFIG_H

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -27,7 +27,7 @@
 #include "terminal-config.h"
 #include "stulto-terminal.h"
 #include "stulto-headerbar.h"
-#include "stulto-global-config.h"
+#include "stulto-app-config.h"
 
 static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer data) {
     GdkScreen *screen = gtk_widget_get_screen(widget);
@@ -121,7 +121,7 @@ static void parse_command_line_options(GOptionEntry *options, GKeyFile *file, gc
 
 gboolean stulto_application_create(int argc, char *argv[]) {
     StultoTerminalConfig *conf = g_malloc(sizeof(StultoTerminalConfig));
-    StultoGlobalConfig *global_conf = g_malloc0(sizeof(StultoGlobalConfig));
+    StultoAppConfig *app_config = g_malloc0(sizeof(StultoAppConfig));
 
     // TODO - when we refactor to GtkApplication, most of these options will go away
     // Those that remain should live in the application type rather than tangled up with the config model
@@ -139,7 +139,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     .long_name = "role",
                     .short_name = 'r',
                     .arg = G_OPTION_ARG_STRING,
-                    .arg_data = &global_conf->role,
+                    .arg_data = &app_config->role,
                     .description = "Set window role",
                     .arg_description = "ROLE",
             },
@@ -148,7 +148,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     // (Assuming there hasn't yet been user uptake AND users don't voice strong opposition)
                     .long_name = "enable-headerbar",
                     .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &global_conf->enable_headerbar,
+                    .arg_data = &app_config->enable_headerbar,
                     .description = "Enable CSD-style headerbar",
             },
             {
@@ -206,7 +206,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     g_signal_connect(window, "delete-event", G_CALLBACK(delete_event), NULL);
 
-    if (global_conf->enable_headerbar)
+    if (app_config->enable_headerbar)
     {
         GtkWidget *header_bar = stulto_headerbar_create();
         gtk_window_set_titlebar(GTK_WINDOW(window), header_bar);
@@ -219,9 +219,9 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     screen_changed(window, NULL, NULL);
     g_signal_connect(window, "screen-changed", G_CALLBACK(screen_changed), NULL);
 
-    if (global_conf->role) {
-        gtk_window_set_role(GTK_WINDOW(window), global_conf->role);
-        g_free(global_conf->role);
+    if (app_config->role) {
+        gtk_window_set_role(GTK_WINDOW(window), app_config->role);
+        g_free(app_config->role);
     }
 
     /* Create the terminal widget and add it to the window */

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -66,7 +66,7 @@ static void switch_page(GtkNotebook *notebook, GtkWidget *child, guint page_num,
      */
 }
 
-static void parse_options(GOptionEntry *options, GKeyFile *file, gchar *filename, GError *error) {
+static void parse_command_line_options(GOptionEntry *options, GKeyFile *file, gchar *filename, GError *error) {
     GOptionEntry *entry;
     gboolean option;
 
@@ -247,7 +247,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     }
 
     stulto_terminal_config_parse(conf, file, filename);
-    parse_options(options, file, filename, error);
+    parse_command_line_options(options, file, filename, error);
 
     /* Create a window to hold the scrolling shell, and hook its
      * delete event to the quit function.. */

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -134,22 +134,6 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     .arg_description = "FILE",
             },
             {
-                    .long_name = "font",
-                    .short_name = 'f',
-                    .arg = G_OPTION_ARG_STRING,
-                    .arg_data = &conf->font,
-                    .description = "Specify a font to use",
-                    .arg_description = "FONT",
-            },
-            {
-                    .long_name = "lines",
-                    .short_name = 'n',
-                    .arg = G_OPTION_ARG_INT,
-                    .arg_data = &conf->lines,
-                    .description = "Specify the number of scrollback lines",
-                    .arg_description = "LINES",
-            },
-            {
                     .long_name = "role",
                     .short_name = 'r',
                     .arg = G_OPTION_ARG_STRING,
@@ -158,42 +142,8 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     .arg_description = "ROLE",
             },
             {
-                    .long_name = "no-decorations",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->nodecorations,
-                    .description = "Disable window decorations",
-            },
-            {
-                    .long_name = "scroll-on-output",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->scroll_on_output,
-                    .description = "Toggle scroll on output",
-            },
-            {
-                    .long_name = "scroll-on-keystroke",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->scroll_on_keystroke,
-                    .description = "Toggle scroll on keystroke",
-            },
-            {
-                    .long_name = "mouse-autohide",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->mouse_autohide,
-                    .description = "Toggle autohiding the mouse cursor",
-            },
-            {
-                    .long_name = "sync-clipboard",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->sync_clipboard,
-                    .description = "Update both primary and clipboard on selection",
-            },
-            {
-                    .long_name = "urgent-on-bell",
-                    .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->urgent_on_bell,
-                    .description = "Set window urgency hint on bell",
-            },
-            {
+                    // TODO - this will become opt-out once the headerbar design is fully implemented
+                    // (Assuming there hasn't yet been user uptake AND users don't voice strong opposition)
                     .long_name = "enable-headerbar",
                     .arg = G_OPTION_ARG_NONE,
                     .arg_data = &conf->enable_headerbar,

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -60,34 +60,10 @@ static void page_added(GtkNotebook *notebook, GtkWidget *child, guint page_num, 
 }
 
 static void switch_page(GtkNotebook *notebook, GtkWidget *child, guint page_num, gpointer data) {
-    gboolean *enable_headerbar = data;
     gtk_widget_show(child);
-
-    gint num_tabs = gtk_notebook_get_n_pages(notebook);
-    gint cur_tab = gtk_notebook_page_num(notebook, child);
-
-    GtkWidget *window = gtk_widget_get_ancestor(GTK_WIDGET(notebook), GTK_TYPE_WINDOW);
-
-    gchar *new_title;
-
-    if (*enable_headerbar)
-    {
-        new_title = g_strdup_printf("Stulto: %s", vte_terminal_get_window_title(VTE_TERMINAL(child)));
-
-        // Not currently used, but we'll eventually plug it in to update the headerbar's session indicator
-        // gchar *new_session_state = g_strdup_printf("%d/%d", cur_tab + 1, num_tabs);
-        // TODO - update session state indicator
-        // g_free(new_session_state);
-    } else {
-        new_title = g_strdup_printf(
-                "[%d/%d] %s",
-                cur_tab + 1,
-                num_tabs,
-                vte_terminal_get_window_title(VTE_TERMINAL(child)));
-    }
-
-    gtk_window_set_title(GTK_WINDOW(window), new_title);
-    g_free(new_title);
+    /* TODO - we were previously passing in a pointer to the window to update its title
+     * What we instead want to do is pick up the notify signal for the notebook's `page` property
+     */
 }
 
 static void parse_options(GOptionEntry *options, GKeyFile *file, gchar *filename, GError *error) {
@@ -307,7 +283,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     gtk_container_add(GTK_CONTAINER(window), notebook);
 
     g_signal_connect(notebook, "page-added", G_CALLBACK(page_added), conf);
-    g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), &conf->enable_headerbar);
+    g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
 
     // For whatever odd reason, the first terminal created, doesn't capture focus automatically
     GtkWidget *term = stulto_terminal_create(conf);

--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -27,6 +27,7 @@
 #include "terminal-config.h"
 #include "stulto-terminal.h"
 #include "stulto-headerbar.h"
+#include "stulto-global-config.h"
 
 static void screen_changed(GtkWidget *widget, GdkScreen *old_screen, gpointer data) {
     GdkScreen *screen = gtk_widget_get_screen(widget);
@@ -120,6 +121,7 @@ static void parse_command_line_options(GOptionEntry *options, GKeyFile *file, gc
 
 gboolean stulto_application_create(int argc, char *argv[]) {
     StultoTerminalConfig *conf = g_malloc(sizeof(StultoTerminalConfig));
+    StultoGlobalConfig *global_conf = g_malloc0(sizeof(StultoGlobalConfig));
 
     // TODO - when we refactor to GtkApplication, most of these options will go away
     // Those that remain should live in the application type rather than tangled up with the config model
@@ -137,7 +139,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     .long_name = "role",
                     .short_name = 'r',
                     .arg = G_OPTION_ARG_STRING,
-                    .arg_data = &conf->role,
+                    .arg_data = &global_conf->role,
                     .description = "Set window role",
                     .arg_description = "ROLE",
             },
@@ -146,7 +148,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
                     // (Assuming there hasn't yet been user uptake AND users don't voice strong opposition)
                     .long_name = "enable-headerbar",
                     .arg = G_OPTION_ARG_NONE,
-                    .arg_data = &conf->enable_headerbar,
+                    .arg_data = &global_conf->enable_headerbar,
                     .description = "Enable CSD-style headerbar",
             },
             {
@@ -204,7 +206,7 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     g_signal_connect(window, "delete-event", G_CALLBACK(delete_event), NULL);
 
-    if (conf->enable_headerbar)
+    if (global_conf->enable_headerbar)
     {
         GtkWidget *header_bar = stulto_headerbar_create();
         gtk_window_set_titlebar(GTK_WINDOW(window), header_bar);
@@ -217,13 +219,9 @@ gboolean stulto_application_create(int argc, char *argv[]) {
     screen_changed(window, NULL, NULL);
     g_signal_connect(window, "screen-changed", G_CALLBACK(screen_changed), NULL);
 
-    if (conf->role) {
-        gtk_window_set_role(GTK_WINDOW(window), conf->role);
-        g_free(conf->role);
-    }
-
-    if (conf->nodecorations) {
-        gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+    if (global_conf->role) {
+        gtk_window_set_role(GTK_WINDOW(window), global_conf->role);
+        g_free(global_conf->role);
     }
 
     /* Create the terminal widget and add it to the window */

--- a/src/stulto-global-config.h
+++ b/src/stulto-global-config.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef STULTO_GLOBAL_CONFIG_H
+#define STULTO_GLOBAL_CONFIG_H
+
+#include <glib.h>
+
+typedef struct _StultoGlobalConfig {
+    gchar *role;
+    gboolean nodecorations;
+    gboolean enable_headerbar;
+    gchar **command_argv;
+} StultoGlobalConfig;
+
+#endif //STULTO_GLOBAL_CONFIG_H

--- a/src/stulto-global-config.h
+++ b/src/stulto-global-config.h
@@ -24,9 +24,7 @@
 
 typedef struct _StultoGlobalConfig {
     gchar *role;
-    gboolean nodecorations;
     gboolean enable_headerbar;
-    gchar **command_argv;
 } StultoGlobalConfig;
 
 #endif //STULTO_GLOBAL_CONFIG_H

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -22,34 +22,10 @@
 #include "exit-status.h"
 
 static void window_title_changed(GtkWidget *widget, gpointer data) {
-    gboolean *enable_headerbar = data;
-    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
-    GtkWidget *notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
-
-    gint num_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
-    gint cur_tab = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-
-    gchar *new_title;
-
-    if (*enable_headerbar)
-    {
-        new_title = g_strdup_printf("Stulto: %s", vte_terminal_get_window_title(VTE_TERMINAL(widget)));
-
-        // Not currently used, but we'll eventually plug it in to update the headerbar's session indicator
-        // gchar *new_session_state = g_strdup_printf("%d/%d", cur_tab + 1, num_tabs);
-        // TODO - update session state indicator
-        // g_free(new_session_state);
-    } else {
-        new_title = g_strdup_printf(
-                "[%d/%d] %s",
-                cur_tab + 1,
-                num_tabs,
-                vte_terminal_get_window_title(VTE_TERMINAL(widget)));
-    }
-
-    gtk_window_set_title(GTK_WINDOW(window), new_title);
-
-    g_free(new_title);
+    /* TODO - we were previously passing in a pointer to the window to update its title
+     * What we instead want to do is pick up the notify signal for the terminal's `window-title` property
+     * At that point, we should also remove this now vestigial comeback
+     */
 }
 
 static void handle_bell(GtkWidget *widget, gpointer data) {
@@ -241,7 +217,7 @@ static void connect_terminal_signals(VteTerminal *terminal, StultoTerminalConfig
     GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
 
     /* Connect to the "window-title-changed" signal to set the main window's title */
-    g_signal_connect(widget, "window-title-changed", G_CALLBACK(window_title_changed), &conf->enable_headerbar);
+    g_signal_connect(widget, "window-title-changed", G_CALLBACK(window_title_changed), NULL);
 
     /* Connect to the "button-press" event. */
     if (conf->program)

--- a/src/terminal-config.c
+++ b/src/terminal-config.c
@@ -19,6 +19,35 @@
 
 #include "terminal-config.h"
 
+static void parse_options(GKeyFile *file, const gchar *filename, StultoTerminalConfig *conf)
+{
+    GError *error = NULL;
+
+    conf->font = g_key_file_get_string(file, "options", "font", &error);
+    conf->lines = g_key_file_get_integer(file, "options", "lines", &error);
+    conf->scroll_on_output = g_key_file_get_boolean(file, "options", "scroll-on-output", &error);
+    conf->scroll_on_keystroke = g_key_file_get_boolean(file, "options", "scroll-on-keystroke", &error);
+    conf->mouse_autohide = g_key_file_get_boolean(file, "options", "mouse-autohide", &error);
+    conf->sync_clipboard = g_key_file_get_boolean(file, "options", "sync-clipboard", &error);
+    conf->urgent_on_bell = g_key_file_get_boolean(file, "options", "urgent-on-bell", &error);
+
+    if (error)
+    {
+        switch (error->code)
+        {
+            case G_KEY_FILE_ERROR_GROUP_NOT_FOUND:
+            case G_KEY_FILE_ERROR_KEY_NOT_FOUND:
+                break;
+            default:
+                g_printerr(
+                        "Error parsing '%s': %s\n", filename, error->message
+                );
+        }
+        g_error_free(error);
+        error = NULL;
+    }
+}
+
 static gboolean parse_color(GKeyFile *file, const gchar *filename, const gchar *key, gboolean required, GdkRGBA *out) {
     GError *error = NULL;
     gchar *color = g_key_file_get_string(file, "colors", key, &error);
@@ -130,6 +159,9 @@ static void parse_urlmatch(GKeyFile *file, const gchar *filename, StultoTerminal
 }
 
 static void parse_file(StultoTerminalConfig *conf, GKeyFile *file, gchar *filename) {
+    if (g_key_file_has_group(file, "options")) {
+        parse_options(file, filename, conf);
+    }
     if (g_key_file_has_group(file, "colors")) {
         parse_colors(file, filename, conf);
     }

--- a/src/terminal-config.h
+++ b/src/terminal-config.h
@@ -33,14 +33,11 @@ typedef struct _StultoTerminalConfig {
     gchar *config_file;
     gchar *font;
     gint lines;
-    gchar *role;
-    gboolean nodecorations;
     gboolean scroll_on_output;
     gboolean scroll_on_keystroke;
     gboolean mouse_autohide;
     gboolean sync_clipboard;
     gboolean urgent_on_bell;
-    gboolean enable_headerbar;
     gchar **command_argv;
 #ifdef VTE_TYPE_REGEX
     VteRegex *regex;


### PR DESCRIPTION
Tl;dr:

* Remove global settings from `StultoTerminalConfig` (and split out into `StultoAppConfig`)
* Decouple parsing of config and command-line options
* Decouple terminal title updates from window title and headerbar state
  * This unfortunately does regress the tab state tracking in both for now, but we'll re-enable this by picking up `notify` signals in the widgets that care about that state