### PR TITLE
Fix Tab Status Indicator in Window Title

### DIFF
--- a/src/stulto-app-config.h
+++ b/src/stulto-app-config.h
@@ -24,6 +24,11 @@
 
 #include "stulto-terminal-profile.h"
 
+/*
+ * An object that stores global/app-wide settings
+ * This will eventually be migrated to GSettings
+ */
+
 typedef struct _StultoAppConfig {
     gchar *role;
     gchar *initial_profile_path; // For this instance of the app

--- a/src/stulto-application.h
+++ b/src/stulto-application.h
@@ -22,6 +22,11 @@
 
 #include <glib.h>
 
+/*
+ * The top-level abstraction of Stulto - i.e., the app itself
+ * This will eventually be migrated to GtkApplication
+ */
+
 gboolean stulto_application_create(int argc, char *argv[]);
 
 int stulto_get_exit_status();

--- a/src/stulto-exec-data.h
+++ b/src/stulto-exec-data.h
@@ -22,6 +22,10 @@
 
 #include <glib.h>
 
+/*
+ * An object that stores data about the command to be executed in a terminal to be opened
+ */
+
 typedef struct _StultoExecData {
     gchar **command_argv;
 } StultoExecData;

--- a/src/stulto-headerbar.h
+++ b/src/stulto-headerbar.h
@@ -22,6 +22,11 @@
 
 #include <gtk/gtk.h>
 
+/*
+ * A Gtk CSD widget for Stulto
+ * This implementation is currently WIP
+ */
+
 GtkWidget *stulto_headerbar_create();
 
 #endif //STULTO_HEADERBAR_H

--- a/src/stulto-main-window.h
+++ b/src/stulto-main-window.h
@@ -25,6 +25,11 @@
 #include "stulto-terminal.h"
 #include "stulto-app-config.h"
 
+/*
+ * The window containing the terminal sessions for this instance of Stulto
+ * This will eventually be migrated to GtkApplicationWindow
+ */
+
 G_BEGIN_DECLS
 
 #define STULTO_TYPE_MAIN_WINDOW stulto_main_window_get_type()

--- a/src/stulto-session-manager.c
+++ b/src/stulto-session-manager.c
@@ -18,7 +18,13 @@
  */
 
 #include "stulto-session-manager.h"
-#include "stulto-terminal.h"
+#include "stulto-session.h"
+
+enum {
+    PROP_0,
+    PROP_ACTIVE_SESSION,
+    N_PROPS
+};
 
 struct _StultoSessionManager {
     GtkNotebook parent_instance;
@@ -26,34 +32,60 @@ struct _StultoSessionManager {
 
 G_DEFINE_FINAL_TYPE(StultoSessionManager, stulto_session_manager, GTK_TYPE_NOTEBOOK)
 
+static GParamSpec *pspecs[N_PROPS] = {NULL };
+
+// region Declarations
+
+/* Vfunc implementations */
 static void stulto_session_manager_dispose(GObject *object);
 static void stulto_session_manager_finalize(GObject *object);
+
+static void stulto_session_manager_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
+static void stulto_session_manager_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
+
 static void stulto_session_manager_init(StultoSessionManager *session_manager);
 static void stulto_session_manager_class_init(StultoSessionManagerClass *klass);
 
-// region Signal Callbacks
+/* Getters & setters */
+StultoSession *stulto_session_manager_get_active_session(StultoSessionManager *session_manager);
+void stulto_session_manager_set_active_session(StultoSessionManager *session_manager, StultoSession *session);
+
+gint stulto_session_manager_get_active_session_id(StultoSessionManager *session_manager);
+void stulto_session_manager_set_active_session_id(StultoSessionManager *session_manager, gint session_id);
+
+gint stulto_session_manager_get_n_sessions(StultoSessionManager *session_manager);
+
+// endregion
+
+// region Callbacks
 
 static void page_added_cb(GtkNotebook *notebook, GtkWidget *child, guint page_num, gpointer data) {
-    StultoTerminal *terminal = STULTO_TERMINAL(child);
+    StultoSessionManager *session_manager = STULTO_SESSION_MANAGER(notebook);
+    StultoSession *session = STULTO_SESSION(child);
+    StultoTerminal *terminal = stulto_session_get_active_terminal(session);
     const char *term_title = stulto_terminal_get_title(terminal);
 
-    gchar *tab_label_txt = g_strdup_printf("%d: %s", page_num, term_title);
-    stulto_terminal_set_title(terminal, tab_label_txt);
+    gchar *new_title = g_strdup(
+            term_title == NULL || term_title[0] == '\0'
+            ? "Stulto"
+            : term_title);
 
-    GtkWidget *tab_label = gtk_label_new(tab_label_txt);
+    stulto_terminal_set_title(terminal, new_title);
 
-    g_free(tab_label_txt);
+    g_free(new_title);
 
-    gtk_notebook_set_tab_label(notebook, child, tab_label);
-
-    gtk_notebook_set_current_page(notebook, (gint) page_num);
+    stulto_session_manager_set_active_session(session_manager, session);
 }
 
 static void switch_page_cb(GtkNotebook *notebook, GtkWidget *child, guint page_num, gpointer data) {
-    gtk_widget_show_all(GTK_WIDGET(child));
+    gtk_widget_show_all(child);
+
+    g_object_notify(G_OBJECT(notebook), "active-session");
 }
 
 // endregion
+
+// region GObject/GtkWidget lifecycle
 
 static void stulto_session_manager_dispose(GObject *object) {
     G_OBJECT_CLASS(stulto_session_manager_parent_class)->dispose(object);
@@ -63,10 +95,33 @@ static void stulto_session_manager_finalize(GObject *object) {
     G_OBJECT_CLASS(stulto_session_manager_parent_class)->finalize(object);
 }
 
-static void stulto_session_manager_init(StultoSessionManager *session_manager) {
-    gtk_notebook_set_show_tabs(GTK_NOTEBOOK(session_manager), FALSE);
-    g_signal_connect(session_manager, "page-added", G_CALLBACK(page_added_cb), NULL);
-    g_signal_connect(session_manager, "switch-page", G_CALLBACK(switch_page_cb), NULL);
+static void stulto_session_manager_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {
+    StultoSessionManager *session_manager = STULTO_SESSION_MANAGER(object);
+
+    switch (prop_id) {
+        case PROP_ACTIVE_SESSION:
+            g_value_set_object(value, STULTO_SESSION(
+                    stulto_session_manager_get_active_session(
+                            session_manager
+                    )));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static void stulto_session_manager_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec) {
+    StultoSessionManager *session_manager = STULTO_SESSION_MANAGER(object);
+
+    switch (prop_id) {
+        case PROP_ACTIVE_SESSION:
+            stulto_session_manager_set_active_session(session_manager, STULTO_SESSION(g_value_get_object(value)));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
 }
 
 static void stulto_session_manager_class_init(StultoSessionManagerClass *klass) {
@@ -74,24 +129,97 @@ static void stulto_session_manager_class_init(StultoSessionManagerClass *klass) 
 
     object_class->dispose = stulto_session_manager_dispose;
     object_class->finalize = stulto_session_manager_finalize;
+    object_class->get_property = stulto_session_manager_get_property;
+    object_class->set_property = stulto_session_manager_set_property;
+
+    pspecs[PROP_ACTIVE_SESSION] = g_param_spec_object(
+            "active-session",
+            "active-session",
+            "The currently selected terminal session",
+            STULTO_TYPE_SESSION,
+            G_PARAM_READWRITE);
+
+    g_object_class_install_properties(object_class, N_PROPS, pspecs);
+}
+
+static void stulto_session_manager_init(StultoSessionManager *session_manager) {
+    gtk_notebook_set_show_tabs(GTK_NOTEBOOK(session_manager), FALSE);
+
+    g_signal_connect(session_manager, "page-added", G_CALLBACK(page_added_cb), NULL);
+    g_signal_connect_after(session_manager, "switch-page", G_CALLBACK(switch_page_cb), NULL);
 }
 
 StultoSessionManager *stulto_session_manager_new() {
     return STULTO_SESSION_MANAGER(g_object_new(STULTO_TYPE_SESSION_MANAGER, NULL));
 }
 
-void stulto_session_manager_add_terminal(StultoSessionManager *session_manager, StultoTerminal *terminal) {
+// endregion
+
+// region Properties
+
+StultoSession *stulto_session_manager_get_active_session(StultoSessionManager *session_manager) {
+    g_return_val_if_fail(STULTO_IS_SESSION_MANAGER(session_manager), NULL);
+
     GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
 
-    gint num_pages = gtk_notebook_get_n_pages(notebook);
-    gchar *label_txt = g_strdup_printf("%d", num_pages);
+    gint current_page = gtk_notebook_get_current_page(notebook);
+
+    GtkWidget *widget = gtk_notebook_get_nth_page(notebook, current_page);
+
+    return STULTO_SESSION(widget);
+}
+
+void stulto_session_manager_set_active_session(StultoSessionManager *session_manager, StultoSession *session) {
+    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
+
+    GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
+
+    gint page_num = gtk_notebook_page_num(notebook, GTK_WIDGET(session));
+
+    g_return_if_fail(page_num >= 0);
+
+    gtk_notebook_set_current_page(notebook, page_num);
+}
+
+gint stulto_session_manager_get_active_session_id(StultoSessionManager *session_manager) {
+    g_return_val_if_fail(STULTO_IS_SESSION_MANAGER(session_manager), -1);
+
+    return gtk_notebook_get_current_page(GTK_NOTEBOOK(session_manager));
+}
+
+void stulto_session_manager_set_active_session_id(StultoSessionManager *session_manager, gint session_id) {
+    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
+
+    gtk_notebook_set_current_page(GTK_NOTEBOOK(session_manager), session_id);
+}
+
+gint stulto_session_manager_get_n_sessions(StultoSessionManager *session_manager) {
+    g_return_val_if_fail(STULTO_IS_SESSION_MANAGER(session_manager), -1);
+
+    GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
+
+    return gtk_notebook_get_n_pages(notebook);
+}
+
+void stulto_session_manager_add_session(StultoSessionManager *session_manager, StultoTerminal *first_terminal) {
+    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
+
+    GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
+
+    gint next_id = gtk_notebook_get_n_pages(notebook);
+    gchar *label_txt = g_strdup_printf("%d", next_id);
     GtkWidget *new_tab_label = gtk_label_new(label_txt);
     g_free(label_txt);
 
-    gtk_notebook_append_page(notebook, GTK_WIDGET(terminal), new_tab_label);
+    StultoSession *session = stulto_session_new(first_terminal);
+    gtk_notebook_append_page(notebook, GTK_WIDGET(session), new_tab_label);
+
+    stulto_session_manager_set_active_session(session_manager, session);
 }
 
 void stulto_session_manager_prev_session(StultoSessionManager *session_manager) {
+    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
+
     GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
 
     gint num_pages = gtk_notebook_get_n_pages(notebook);
@@ -99,15 +227,20 @@ void stulto_session_manager_prev_session(StultoSessionManager *session_manager) 
 
     gint cur_page_num = gtk_notebook_get_current_page(notebook);
 
-    if (cur_page_num == 0) {
-        gtk_notebook_set_current_page(notebook, last_page);
-        return;
-    }
+    g_return_if_fail(cur_page_num >= 0);
 
-    gtk_notebook_prev_page(notebook);
+    gint new_page_num = cur_page_num == 0 ? last_page : cur_page_num - 1;
+
+    GtkWidget *new_page_widget = gtk_notebook_get_nth_page(notebook, new_page_num);
+
+    StultoSession *new_active_session = STULTO_SESSION(new_page_widget);
+
+    stulto_session_manager_set_active_session(session_manager, new_active_session);
 }
 
 void stulto_session_manager_next_session(StultoSessionManager *session_manager) {
+    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
+
     GtkNotebook *notebook = GTK_NOTEBOOK(session_manager);
 
     gint num_pages = gtk_notebook_get_n_pages(notebook);
@@ -115,10 +248,15 @@ void stulto_session_manager_next_session(StultoSessionManager *session_manager) 
 
     gint cur_page_num = gtk_notebook_get_current_page(notebook);
 
-    if (cur_page_num == last_page) {
-        gtk_notebook_set_current_page(notebook, 0);
-        return;
-    }
+    g_return_if_fail(cur_page_num >= 0);
 
-    gtk_notebook_next_page(notebook);
+    gint new_page_num = cur_page_num == last_page ? 0 : cur_page_num + 1;
+
+    GtkWidget *new_page_widget = gtk_notebook_get_nth_page(notebook, new_page_num);
+
+    StultoSession *new_active_session = STULTO_SESSION(new_page_widget);
+
+    stulto_session_manager_set_active_session(session_manager, new_active_session);
 }
+
+// endregion

--- a/src/stulto-session-manager.h
+++ b/src/stulto-session-manager.h
@@ -23,6 +23,7 @@
 #include <gtk/gtk.h>
 
 #include "stulto-terminal.h"
+#include "stulto-session.h"
 
 G_BEGIN_DECLS
 
@@ -30,13 +31,19 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(StultoSessionManager, stulto_session_manager, STULTO, SESSION_MANAGER, GtkNotebook)
 
 StultoSessionManager *stulto_session_manager_new();
-void stulto_session_manager_add_terminal(StultoSessionManager *session_manager, StultoTerminal *terminal);
+
+StultoSession *stulto_session_manager_get_active_session(StultoSessionManager *session_manager);
+void stulto_session_manager_set_active_session(StultoSessionManager *session_manager, StultoSession *session);
+
+gint stulto_session_manager_get_active_session_id(StultoSessionManager *session_manager);
+void stulto_session_manager_set_active_session_id(StultoSessionManager *session_manager, gint session_id);
+
+gint stulto_session_manager_get_n_sessions(StultoSessionManager *session_manager);
+
+void stulto_session_manager_add_session(StultoSessionManager *session_manager, StultoTerminal *first_terminal);
 
 void stulto_session_manager_prev_session(StultoSessionManager *session_manager);
 void stulto_session_manager_next_session(StultoSessionManager *session_manager);
-
-gint stulto_session_manager_get_current_terminal(StultoSessionManager *session_manager);
-gint stulto_session_manager_get_n_terminals(StultoSessionManager *session_manager);
 
 G_END_DECLS
 

--- a/src/stulto-session-manager.h
+++ b/src/stulto-session-manager.h
@@ -35,6 +35,9 @@ void stulto_session_manager_add_terminal(StultoSessionManager *session_manager, 
 void stulto_session_manager_prev_session(StultoSessionManager *session_manager);
 void stulto_session_manager_next_session(StultoSessionManager *session_manager);
 
+gint stulto_session_manager_get_current_terminal(StultoSessionManager *session_manager);
+gint stulto_session_manager_get_n_terminals(StultoSessionManager *session_manager);
+
 G_END_DECLS
 
 #endif //STULTO_SESSION_MANAGER_H

--- a/src/stulto-session.c
+++ b/src/stulto-session.c
@@ -1,0 +1,157 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "stulto-session.h"
+
+struct _StultoSession {
+    GtkBin parent_instance;
+
+    StultoTerminal *active_terminal;
+};
+
+G_DEFINE_FINAL_TYPE(StultoSession, stulto_session, GTK_TYPE_BIN)
+
+enum {
+    PROP_0,
+    PROP_ACTIVE_TERMINAL,
+    N_PROPERTIES
+};
+
+static GParamSpec *obj_properties[N_PROPERTIES] = { NULL };
+
+// region Declarations
+
+/* Vfunc implementations */
+static void stulto_session_dispose(GObject *object);
+static void stulto_session_finalize(GObject *object);
+
+static void stulto_session_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
+static void stulto_session_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
+
+static void stulto_session_class_init(StultoSessionClass *klass);
+static void stulto_session_init(StultoSession *session);
+
+StultoSession *stulto_session_new(StultoTerminal *terminal);
+
+/* Getters & setters */
+StultoTerminal *stulto_session_get_active_terminal(StultoSession *session);
+void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *terminal);
+
+gint stulto_session_get_active_terminal_id(StultoSession *session);
+void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id);
+
+// endregion
+
+// region GObject/GtkWidget lifecycle
+
+static void stulto_session_dispose(GObject *object) {
+    G_OBJECT_CLASS(stulto_session_parent_class)->dispose(object);
+}
+
+static void stulto_session_finalize(GObject *object) {
+    G_OBJECT_CLASS(stulto_session_parent_class)->finalize(object);
+}
+
+static void stulto_session_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {
+    StultoSession *session = STULTO_SESSION(object);
+
+    switch (prop_id)
+    {
+        case PROP_ACTIVE_TERMINAL:
+            g_value_set_object(value, STULTO_TERMINAL(stulto_session_get_active_terminal(session)));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static void stulto_session_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec) {
+    StultoSession *session = STULTO_SESSION(object);
+
+    switch (prop_id)
+    {
+        case PROP_ACTIVE_TERMINAL:
+            stulto_session_set_active_terminal(session, g_value_get_object(value));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static void stulto_session_class_init(StultoSessionClass *klass) {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+    object_class->dispose = stulto_session_dispose;
+    object_class->finalize = stulto_session_finalize;
+    object_class->get_property = stulto_session_get_property;
+    object_class->set_property = stulto_session_set_property;
+
+    obj_properties[PROP_ACTIVE_TERMINAL] = g_param_spec_object(
+            "active-terminal",
+            "active-terminal",
+            "The session's active terminal widget",
+            STULTO_TYPE_TERMINAL,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+    g_object_class_install_properties(object_class, N_PROPERTIES, obj_properties);
+}
+
+static void stulto_session_init(StultoSession *session) {
+    // Nothing to do here
+}
+
+StultoSession *stulto_session_new(StultoTerminal *terminal)
+{
+    StultoSession *session = STULTO_SESSION(g_object_new(
+            STULTO_TYPE_SESSION,
+            "active-terminal", terminal,
+            NULL
+    ));
+
+    session->active_terminal = terminal;
+
+    return session;
+}
+
+// endregion
+
+// region Properties
+
+StultoTerminal *stulto_session_get_active_terminal(StultoSession *session) {
+    return session->active_terminal;
+}
+
+void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *terminal) {
+    session->active_terminal = terminal;
+
+    gtk_container_add(GTK_CONTAINER(session), GTK_WIDGET(terminal));
+}
+
+gint stulto_session_get_active_terminal_id(StultoSession *session) {
+    // TODO - un-stub
+    return 0;
+}
+
+void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id) {
+    // TODO - un-stub
+}
+
+// endregion

--- a/src/stulto-session.h
+++ b/src/stulto-session.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Stulto.
+ * Copyright (C) 2022 Marĉjo Givens
+ *
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef STULTO_SESSION_H
+#define STULTO_SESSION_H
+
+#include <gtk/gtk.h>
+#include "stulto-terminal.h"
+
+/**
+ * A container type that hosts multiple terminal sessions as tiled widgets
+ * WIP - currently only hosts a single session
+ */
+
+G_BEGIN_DECLS
+
+#define STULTO_TYPE_SESSION stulto_session_get_type()
+G_DECLARE_FINAL_TYPE(StultoSession, stulto_session, STULTO, SESSION, GtkBin)
+
+StultoSession *stulto_session_new(StultoTerminal *terminal);
+
+StultoTerminal *stulto_session_get_active_terminal(StultoSession *session);
+void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *terminal);
+
+gint stulto_session_get_active_terminal_id(StultoSession *session);
+void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id);
+
+G_END_DECLS
+
+#endif //STULTO_SESSION_H

--- a/src/stulto-terminal-profile.h
+++ b/src/stulto-terminal-profile.h
@@ -29,6 +29,15 @@
 
 #endif
 
+/*
+ * An object that stores settings specifically for a terminal widget
+ *
+ * Currently, this is specified at startup and applied to every subsequent terminal opened in the same instance of the
+ * application
+ *
+ * Eventually, we'll implement functionality to allow selecting profiles per-terminal at runtime
+ */
+
 typedef struct _StultoTerminalProfile {
     gchar *config_file;
     gchar *font;

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -21,47 +21,66 @@
 
 #include "exit-status.h"
 
-#define STULTO_TERMINAL_TITLEBAR_STYLE_CLASS "stulto-terminal-titlebar"
-
-enum {
-    PROP_0,
-    // TODO - profile is currently not actually implemented as a property - probably want to do this w/GSettings
-    PROP_PROFILE,
-    PROP_TITLE,
-};
-
 struct _StultoTerminal {
     GtkBin parent_instance;
 
     StultoTerminalProfile *profile;
     StultoExecData *exec_data;
 
-    GtkLabel *title;
-    VteTerminal *vte;
+    gchar *title;
+
+    GtkLabel *title_widget;
+    VteTerminal *terminal_widget;
 };
 
 G_DEFINE_FINAL_TYPE(StultoTerminal, stulto_terminal, GTK_TYPE_BIN)
 
+enum {
+    PROP_0,
+    PROP_TITLE,
+    N_PROPERTIES
+};
+
+static GParamSpec *obj_properties[N_PROPERTIES] = { NULL };
+
+#define STULTO_TERMINAL_TITLEBAR_STYLE_CLASS "stulto-terminal-titlebar"
+
+// region Declarations
+
+/* Vfunc implementations */
 static void stulto_terminal_dispose(GObject *object);
 static void stulto_terminal_finalize(GObject *object);
 
+static void stulto_terminal_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
+static void stulto_terminal_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
+
 static void stulto_terminal_realize(GtkWidget *widget);
 
-static void stulto_terminal_init(StultoTerminal *terminal);
 static void stulto_terminal_class_init(StultoTerminalClass *klass);
+static void stulto_terminal_init(StultoTerminal *terminal);
+
+StultoTerminal *stulto_terminal_new(StultoTerminalProfile *profile, StultoExecData *exec_data);
+
+/* Getters & setters */
+static void stulto_terminal_set_profile(StultoTerminal *terminal, StultoTerminalProfile *profile);
 
 const char *stulto_terminal_get_title(StultoTerminal *terminal);
-void stulto_terminal_set_title(StultoTerminal *terminal, const char *title);
+void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title);
 
-// region Signal Callbacks
+// endregion
 
-static void vte_window_title_changed_cb(VteTerminal *vte, gpointer data) {
-    // TODO - hoist this so that we can add session index and update the app window title
-    GtkWidget *parent = gtk_widget_get_ancestor(GTK_WIDGET(vte), STULTO_TYPE_TERMINAL);
+// region Callbacks
 
-    StultoTerminal *terminal = STULTO_TERMINAL(parent);
+static void vte_window_title_changed_cb(VteTerminal *terminal_widget, gpointer data) {
+    GtkWidget *parent = gtk_widget_get_ancestor(GTK_WIDGET(terminal_widget), STULTO_TYPE_TERMINAL);
 
-    stulto_terminal_set_title(terminal, vte_terminal_get_window_title(vte));
+    const gchar *vte_title = vte_terminal_get_window_title(terminal_widget);
+
+    gchar *new_title = g_strdup(vte_title);
+
+    stulto_terminal_set_title(STULTO_TERMINAL(parent), new_title);
+
+    g_object_notify(G_OBJECT(parent), "title");
 }
 
 static void vte_bell_cb(GtkWidget *widget, gpointer data) {
@@ -82,10 +101,10 @@ static void vte_child_exited_cb(VteTerminal *widget, int status, gpointer data) 
     GtkWidget *notebook = gtk_widget_get_ancestor(GTK_WIDGET(widget), GTK_TYPE_NOTEBOOK);
     GtkWidget *window = gtk_widget_get_ancestor(GTK_WIDGET(notebook), GTK_TYPE_WINDOW);
 
-    gint numPages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
+    gint num_pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
     gint currentPage = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
 
-    if (numPages > 1) {
+    if (num_pages > 1) {
         gtk_notebook_remove_page(GTK_NOTEBOOK(notebook), currentPage);
         return;
     }
@@ -121,14 +140,22 @@ static gboolean vte_button_press_event_cb(GtkWidget *widget, GdkEvent *event, gp
     return FALSE;
 }
 
+static gboolean vte_selection_changed_cb(VteTerminal *terminal_widget, gpointer data) {
+    if (vte_terminal_get_has_selection(terminal_widget)) {
+        vte_terminal_copy_clipboard_format(terminal_widget, VTE_FORMAT_TEXT);
+    }
+
+    return TRUE;
+}
+
 static void vte_resize_window_cb(GtkWidget *widget, guint width, guint height, gpointer data) {
     GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
-    VteTerminal *terminal = VTE_TERMINAL(widget);
+    VteTerminal *terminal_widget = VTE_TERMINAL(widget);
 
-    glong row_count = vte_terminal_get_row_count(terminal);
-    glong column_count = vte_terminal_get_column_count(terminal);
-    glong char_width = vte_terminal_get_char_width(terminal);
-    glong char_height = vte_terminal_get_char_height(terminal);
+    glong row_count = vte_terminal_get_row_count(terminal_widget);
+    glong column_count = vte_terminal_get_column_count(terminal_widget);
+    glong char_width = vte_terminal_get_char_width(terminal_widget);
+    glong char_height = vte_terminal_get_char_height(terminal_widget);
     gint owidth;
     gint oheight;
     GtkBorder padding;
@@ -153,24 +180,34 @@ static void vte_resize_window_cb(GtkWidget *widget, guint width, guint height, g
     gtk_window_resize(GTK_WINDOW(window), width + owidth, height + oheight);
 }
 
-static gboolean vte_selection_changed_cb(VteTerminal *terminal, gpointer data) {
-    if (vte_terminal_get_has_selection(terminal)) {
-        vte_terminal_copy_clipboard_format(terminal, VTE_FORMAT_TEXT);
+static void vte_terminal_spawn_cb(VteTerminal *terminal_widget, GPid pid, GError *error, gpointer data) {
+    GtkWidget *widget = GTK_WIDGET(terminal_widget);
+    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+
+    if (pid < 0) {
+        g_printerr("%s\n", error->message);
+        g_error_free(error);
+        stulto_destroy_and_quit(window);
+
+        return;
     }
 
-    return TRUE;
+    g_signal_connect(widget, "child-exited", G_CALLBACK(vte_child_exited_cb), NULL);
 }
 
 // endregion
 
-static void connect_terminal_signals(VteTerminal *vte, StultoTerminalProfile *profile) {
+// region Helpers
+// TODO - this section needs to go away - inline all of thise code into the lifecycle functions
+
+static void connect_terminal_signals(VteTerminal *terminal_widget, StultoTerminalProfile *profile) {
     // TODO - we're passing a window reference into callbacks before we even have an ancestor window
     // We should either store a reference to the window, handle these signals _in_ the window object,
     // or bubble them up via g_object_notify
-    GtkWidget *widget = GTK_WIDGET(vte);
+    GtkWidget *widget = GTK_WIDGET(terminal_widget);
 
     /* Connect to the "window-title-changed" signal to set the main window's title */
-    g_signal_connect(vte, "window-title-changed", G_CALLBACK(vte_window_title_changed_cb), NULL);
+    g_signal_connect(terminal_widget, "window-title-changed", G_CALLBACK(vte_window_title_changed_cb), NULL);
 
     /* Connect to the "button-press" event. */
     if (profile->program) {
@@ -192,57 +229,46 @@ static void connect_terminal_signals(VteTerminal *vte, StultoTerminalProfile *pr
     }
 }
 
-static void configure_terminal(VteTerminal *terminal, StultoTerminalProfile *profile) {
+static void configure_terminal(VteTerminal *terminal_widget, StultoTerminalProfile *profile) {
     /* Set some defaults. */
-    vte_terminal_set_scroll_on_output(terminal, profile->scroll_on_output);
-    vte_terminal_set_scroll_on_keystroke(terminal, profile->scroll_on_keystroke);
-    vte_terminal_set_mouse_autohide(terminal, profile->mouse_autohide);
-    vte_terminal_set_cursor_blink_mode(terminal, VTE_CURSOR_BLINK_OFF);
-    vte_terminal_set_cursor_shape(terminal, VTE_CURSOR_SHAPE_BLOCK);
-    vte_terminal_set_bold_is_bright(terminal, profile->bold_is_bright);
+    vte_terminal_set_scroll_on_output(terminal_widget, profile->scroll_on_output);
+    vte_terminal_set_scroll_on_keystroke(terminal_widget, profile->scroll_on_keystroke);
+    vte_terminal_set_mouse_autohide(terminal_widget, profile->mouse_autohide);
+    vte_terminal_set_cursor_blink_mode(terminal_widget, VTE_CURSOR_BLINK_OFF);
+    vte_terminal_set_cursor_shape(terminal_widget, VTE_CURSOR_SHAPE_BLOCK);
+    vte_terminal_set_bold_is_bright(terminal_widget, profile->bold_is_bright);
     if (profile->lines) {
-        vte_terminal_set_scrollback_lines(terminal, profile->lines);
+        vte_terminal_set_scrollback_lines(terminal_widget, profile->lines);
     }
     if (profile->palette_size) {
-        vte_terminal_set_colors(terminal, &profile->foreground, &profile->background, profile->palette, profile->palette_size - 2);
+        vte_terminal_set_colors(terminal_widget, &profile->foreground, &profile->background, profile->palette, profile->palette_size - 2);
     }
     if (profile->highlight.alpha) {
-        vte_terminal_set_color_highlight(terminal, &profile->highlight);
+        vte_terminal_set_color_highlight(terminal_widget, &profile->highlight);
     }
     if (profile->highlight_fg.alpha) {
-        vte_terminal_set_color_highlight_foreground(terminal, &profile->highlight_fg);
+        vte_terminal_set_color_highlight_foreground(terminal_widget, &profile->highlight_fg);
     }
     if (profile->font) {
         PangoFontDescription *desc = pango_font_description_from_string(profile->font);
 
-        vte_terminal_set_font(terminal, desc);
+        vte_terminal_set_font(terminal_widget, desc);
         pango_font_description_free(desc);
     }
     if (profile->regex) {
 #ifdef VTE_TYPE_REGEX
-        int id = vte_terminal_match_add_regex(terminal, profile->regex, 0);
+        int id = vte_terminal_match_add_regex(terminal_widget, profile->regex, 0);
 #else
-        int id = vte_terminal_match_add_gregex(terminal, profile->regex, 0);
+        int id = vte_terminal_match_add_gregex(terminal_widget, profile->regex, 0);
         g_regex_unref(profile->regex);
 #endif
-        vte_terminal_match_set_cursor_name(terminal, id, "pointer");
+        vte_terminal_match_set_cursor_name(terminal_widget, id, "pointer");
     }
 }
 
-static void spawn_callback(VteTerminal *terminal, GPid pid, GError *error, gpointer data) {
-    GtkWidget *widget = GTK_WIDGET(terminal);
-    GtkWidget *window = gtk_widget_get_ancestor(widget, GTK_TYPE_WINDOW);
+// endregion
 
-    if (pid < 0) {
-        g_printerr("%s\n", error->message);
-        g_error_free(error);
-        stulto_destroy_and_quit(window);
-
-        return;
-    }
-
-    g_signal_connect(widget, "child-exited", G_CALLBACK(vte_child_exited_cb), NULL);
-}
+// region GObject/GtkWidget lifecycle
 
 static void stulto_terminal_dispose(GObject *object) {
     G_OBJECT_CLASS(stulto_terminal_parent_class)->dispose(object);
@@ -252,13 +278,45 @@ static void stulto_terminal_finalize(GObject *object) {
     G_OBJECT_CLASS(stulto_terminal_parent_class)->finalize(object);
 }
 
+static void stulto_terminal_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {
+    StultoTerminal *terminal = STULTO_TERMINAL(object);
+
+    switch (prop_id)
+    {
+        case PROP_TITLE:
+            g_value_set_string (value, stulto_terminal_get_title(terminal));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static void stulto_terminal_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec) {
+    StultoTerminal *screen = STULTO_TERMINAL(object);
+
+    switch (prop_id)
+    {
+        case PROP_TITLE:
+        {
+            gchar *new_title = g_strdup(g_value_get_string(value));
+            stulto_terminal_set_title(screen, new_title);
+            g_free(new_title);
+        }
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
 static void stulto_terminal_realize(GtkWidget *widget) {
     StultoTerminal *terminal = STULTO_TERMINAL(widget);
 
     GTK_WIDGET_CLASS(stulto_terminal_parent_class)->realize(widget);
 
     vte_terminal_spawn_async(
-            terminal->vte,
+            terminal->terminal_widget,
             VTE_PTY_DEFAULT,
             NULL,
             terminal->exec_data->command_argv, /* TODO - this should be configurable */
@@ -268,9 +326,29 @@ static void stulto_terminal_realize(GtkWidget *widget) {
             NULL,
             NULL,
             -1,
-            NULL,
-            &spawn_callback,
+            NULL, &vte_terminal_spawn_cb,
             NULL);
+}
+
+static void stulto_terminal_class_init(StultoTerminalClass *klass) {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
+
+    object_class->dispose = stulto_terminal_dispose;
+    object_class->finalize = stulto_terminal_finalize;
+    object_class->get_property = stulto_terminal_get_property;
+    object_class->set_property = stulto_terminal_set_property;
+
+    widget_class->realize = stulto_terminal_realize;
+
+    obj_properties[PROP_TITLE] = g_param_spec_string(
+            "title",
+            "title",
+            "The terminal's window title",
+            "Stulto",
+            G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+    g_object_class_install_properties(object_class, G_N_ELEMENTS(obj_properties), obj_properties);
 }
 
 static void stulto_terminal_init(StultoTerminal *terminal) {
@@ -287,117 +365,78 @@ static void stulto_terminal_init(StultoTerminal *terminal) {
 
     gtk_box_pack_start(GTK_BOX(box), titlebar, FALSE, FALSE, 0);
 
-    GtkWidget *vte = vte_terminal_new();
-    gtk_box_pack_start(GTK_BOX(box), vte, TRUE, TRUE, 0);
+    GtkWidget *terminal_widget = vte_terminal_new();
+    gtk_box_pack_start(GTK_BOX(box), terminal_widget, TRUE, TRUE, 0);
 
     gtk_container_add(GTK_CONTAINER(terminal), box);
 
-    terminal->vte = VTE_TERMINAL(vte);
-    terminal->title = GTK_LABEL(label);
-}
-
-static void stulto_terminal_set_exec_data(StultoTerminal *terminal, StultoExecData *exec_data)
-{
-    terminal->exec_data = exec_data;
-}
-
-static void stulto_terminal_set_profile(StultoTerminal *terminal, StultoTerminalProfile *profile) {
-    terminal->profile = profile;
-    connect_terminal_signals(VTE_TERMINAL(terminal->vte), terminal->profile);
-    configure_terminal(VTE_TERMINAL(terminal->vte), terminal->profile);
-}
-
-const char *stulto_terminal_get_title(StultoTerminal *terminal) {
-    return vte_terminal_get_window_title(VTE_TERMINAL(terminal->vte));
-}
-
-void stulto_terminal_set_title(StultoTerminal *terminal, const char *title) {
-    GtkLabel *title_widget = GTK_LABEL(terminal->title);
-
-    gtk_label_set_text(title_widget, title);
-}
-
-static void stulto_terminal_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
-{
-    StultoTerminal *terminal = STULTO_TERMINAL(object);
-
-    switch (prop_id)
-    {
-        case PROP_TITLE:
-            g_value_set_string (value, stulto_terminal_get_title(terminal));
-            break;
-        default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-            break;
-    }
-}
-
-static void stulto_terminal_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
-{
-    StultoTerminal *screen = STULTO_TERMINAL(object);
-
-    switch (prop_id)
-    {
-        case PROP_PROFILE:
-            stulto_terminal_set_profile(screen, (StultoTerminalProfile *) value);
-            break;
-        default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-            break;
-    }
-}
-
-static void stulto_terminal_class_init(StultoTerminalClass *klass) {
-    GObjectClass *object_class = G_OBJECT_CLASS(klass);
-    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
-
-    object_class->dispose = stulto_terminal_dispose;
-    object_class->finalize = stulto_terminal_finalize;
-    object_class->get_property = stulto_terminal_get_property;
-    object_class->set_property = stulto_terminal_set_property;
-
-    widget_class->realize = stulto_terminal_realize;
-
-    g_object_class_install_property(
-            object_class,
-            PROP_TITLE,
-            g_param_spec_string(
-                    "title",
-                    "title",
-                    "The terminal's title",
-                    "Stulto",
-                    G_PARAM_READABLE
-            ));
+    terminal->terminal_widget = VTE_TERMINAL(terminal_widget);
+    terminal->title_widget = GTK_LABEL(label);
 }
 
 StultoTerminal *stulto_terminal_new(StultoTerminalProfile *profile, StultoExecData *exec_data) {
-    StultoTerminal *terminal = g_object_new(stulto_terminal_get_type(), NULL);
+    StultoTerminal *terminal = STULTO_TERMINAL(g_object_new(STULTO_TYPE_TERMINAL, NULL));
 
     stulto_terminal_set_profile(terminal, profile);
-    stulto_terminal_set_exec_data(terminal, exec_data);
-    stulto_terminal_set_title(terminal, "Stulto");
+    terminal->exec_data = exec_data;
 
     return terminal;
 }
 
-void stulto_terminal_increase_font_size(StultoTerminal *terminal) {
-    VteTerminal *vte = terminal->vte;
+// endregion
 
-    gdouble scale = vte_terminal_get_font_scale(vte);
-    vte_terminal_set_font_scale(vte, scale * 1.125);
+// region Properties
+
+static void stulto_terminal_set_profile(StultoTerminal *terminal, StultoTerminalProfile *profile) {
+    terminal->profile = profile;
+
+    connect_terminal_signals(VTE_TERMINAL(terminal->terminal_widget), terminal->profile);
+
+    configure_terminal(VTE_TERMINAL(terminal->terminal_widget), terminal->profile);
+}
+
+const char *stulto_terminal_get_title(StultoTerminal *terminal) {
+    return terminal->title;
+}
+
+void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title) {
+    if (terminal->title) {
+        g_free(terminal->title);
+    }
+
+    terminal->title = g_strdup(title);
+
+    gchar *new_title_text = g_strdup(terminal->title);
+
+    gtk_label_set_label(GTK_LABEL(terminal->title_widget), new_title_text);
+
+    g_free(new_title_text);
+}
+
+// endregion
+
+// region Key-press actions
+
+void stulto_terminal_increase_font_size(StultoTerminal *terminal) {
+    VteTerminal *terminal_widget = terminal->terminal_widget;
+
+    gdouble scale = vte_terminal_get_font_scale(terminal_widget);
+    vte_terminal_set_font_scale(terminal_widget, scale * 1.125);
 }
 
 void stulto_terminal_decrease_font_size(StultoTerminal *terminal) {
-    VteTerminal *vte = terminal->vte;
+    VteTerminal *terminal_widget = terminal->terminal_widget;
 
-    gdouble scale = vte_terminal_get_font_scale(vte);
-    vte_terminal_set_font_scale(vte, scale / 1.125);
+    gdouble scale = vte_terminal_get_font_scale(terminal_widget);
+    vte_terminal_set_font_scale(terminal_widget, scale / 1.125);
 }
 
 void stulto_terminal_copy_clipboard_format(StultoTerminal *terminal, VteFormat format) {
-    vte_terminal_copy_clipboard_format(terminal->vte, format);
+    vte_terminal_copy_clipboard_format(terminal->terminal_widget, format);
 }
 
 void stulto_terminal_paste_clipboard(StultoTerminal *terminal) {
-    vte_terminal_paste_clipboard(terminal->vte);
+    vte_terminal_paste_clipboard(terminal->terminal_widget);
 }
+
+// endregion

--- a/src/stulto-terminal.h
+++ b/src/stulto-terminal.h
@@ -38,7 +38,7 @@ G_DECLARE_FINAL_TYPE(StultoTerminal, stulto_terminal, STULTO, TERMINAL, GtkBin)
 StultoTerminal *stulto_terminal_new(StultoTerminalProfile *profile, StultoExecData *exec_data);
 
 const char *stulto_terminal_get_title(StultoTerminal *terminal);
-void stulto_terminal_set_title(StultoTerminal *terminal, const char *title);
+void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title);
 
 void stulto_terminal_increase_font_size(StultoTerminal *terminal);
 void stulto_terminal_decrease_font_size(StultoTerminal *terminal);

--- a/src/stulto-terminal.h
+++ b/src/stulto-terminal.h
@@ -25,6 +25,11 @@
 #include "stulto-terminal-profile.h"
 #include "stulto-exec-data.h"
 
+/*
+ * This is Stulto's terminal widget - essentially a typical VteTerminal, but configured via its own config object type
+ * and rendered with a titlebar which indicates the session index and the current terminal process
+ */
+
 G_BEGIN_DECLS
 
 #define STULTO_TYPE_TERMINAL stulto_terminal_get_type()


### PR DESCRIPTION
This fix comes temporarily at the expense of tracking terminal Id in the terminal widget's title bar. This'll come back with the advent of tiled terminals; it's arguably pointless (and potentially confusing) for the purposes of single-terminal tab pages.