### PR TITLE
Handle Font Resize Callbacks Directly in the Terminal Widget

### DIFF
--- a/src/stulto-main-window.c
+++ b/src/stulto-main-window.c
@@ -99,7 +99,6 @@ static void delete_event_cb(GtkWidget *window, GdkEvent *event, gpointer data) {
 
 static gboolean key_press_event_cb(GtkWidget *widget, GdkEvent *event, gpointer data) {
     StultoMainWindow *main_widow = STULTO_MAIN_WINDOW(widget);
-    StultoTerminal *active_terminal = main_widow->active_terminal;
     StultoSessionManager *session_manager = main_widow->session_manager;
 
     GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
@@ -107,21 +106,7 @@ static gboolean key_press_event_cb(GtkWidget *widget, GdkEvent *event, gpointer 
     g_assert(event->type == GDK_KEY_PRESS);
 
     if ((event->key.state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
-        switch (event->key.hardware_keycode) {
-            case 21: /* + on US keyboards */
-                stulto_terminal_increase_font_size(active_terminal);
-                return TRUE;
-            case 20: /* - on US keyboards */
-                stulto_terminal_decrease_font_size(active_terminal);
-                return TRUE;
-        }
         switch (gdk_keyval_to_lower(event->key.keyval)) {
-            case GDK_KEY_c:
-                stulto_terminal_copy_clipboard_format(active_terminal, VTE_FORMAT_TEXT);
-                return TRUE;
-            case GDK_KEY_v:
-                stulto_terminal_paste_clipboard(active_terminal);
-                return TRUE;
             case GDK_KEY_t:
                 stulto_session_manager_add_session(
                         session_manager,

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -449,29 +449,3 @@ void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title) {
 }
 
 // endregion
-
-// region Key-press actions
-
-void stulto_terminal_increase_font_size(StultoTerminal *terminal) {
-    VteTerminal *terminal_widget = terminal->terminal_widget;
-
-    gdouble scale = vte_terminal_get_font_scale(terminal_widget);
-    vte_terminal_set_font_scale(terminal_widget, scale * 1.125);
-}
-
-void stulto_terminal_decrease_font_size(StultoTerminal *terminal) {
-    VteTerminal *terminal_widget = terminal->terminal_widget;
-
-    gdouble scale = vte_terminal_get_font_scale(terminal_widget);
-    vte_terminal_set_font_scale(terminal_widget, scale / 1.125);
-}
-
-void stulto_terminal_copy_clipboard_format(StultoTerminal *terminal, VteFormat format) {
-    vte_terminal_copy_clipboard_format(terminal->terminal_widget, format);
-}
-
-void stulto_terminal_paste_clipboard(StultoTerminal *terminal) {
-    vte_terminal_paste_clipboard(terminal->terminal_widget);
-}
-
-// endregion

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -114,6 +114,38 @@ static void vte_child_exited_cb(VteTerminal *widget, int status, gpointer data) 
     stulto_destroy_and_quit(window);
 }
 
+static gboolean key_press_event_cb(GtkWidget *widget, GdkEvent *event, gpointer data) {
+    VteTerminal *vte = VTE_TERMINAL(widget);
+
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+
+    g_assert(event->type == GDK_KEY_PRESS);
+
+    if ((event->key.state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+        switch (event->key.hardware_keycode) {
+            case 21: /* + on US keyboards */
+                vte_terminal_set_font_scale(vte, vte_terminal_get_font_scale(vte) * 1.25);
+                return TRUE;
+            case 20: /* - on US keyboards */
+                vte_terminal_set_font_scale(vte, vte_terminal_get_font_scale(vte) / 1.25);
+                return TRUE;
+            case 19: /* zero/right parenthesis on US keyboards */
+                vte_terminal_set_font_scale(vte, 1);
+                return TRUE;
+        }
+        switch (gdk_keyval_to_lower(event->key.keyval)) {
+            case GDK_KEY_c:
+                vte_terminal_copy_clipboard_format(vte, VTE_FORMAT_TEXT);
+                return TRUE;
+            case GDK_KEY_v:
+                vte_terminal_paste_clipboard(vte);
+                return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
 static gboolean vte_button_press_event_cb(GtkWidget *widget, GdkEvent *event, gpointer data) {
     gchar *program = data;
 
@@ -209,6 +241,8 @@ static void connect_terminal_signals(VteTerminal *terminal_widget, StultoTermina
 
     /* Connect to the "window-title-changed" signal to set the main window's title */
     g_signal_connect(terminal_widget, "window-title-changed", G_CALLBACK(vte_window_title_changed_cb), NULL);
+
+    g_signal_connect(terminal_widget, "key-press-event", G_CALLBACK(key_press_event_cb), NULL);
 
     /* Connect to the "button-press" event. */
     if (profile->program) {

--- a/src/stulto-terminal.h
+++ b/src/stulto-terminal.h
@@ -40,12 +40,6 @@ StultoTerminal *stulto_terminal_new(StultoTerminalProfile *profile, StultoExecDa
 const char *stulto_terminal_get_title(StultoTerminal *terminal);
 void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title);
 
-void stulto_terminal_increase_font_size(StultoTerminal *terminal);
-void stulto_terminal_decrease_font_size(StultoTerminal *terminal);
-
-void stulto_terminal_copy_clipboard_format(StultoTerminal *terminal, VteFormat format);
-void stulto_terminal_paste_clipboard(StultoTerminal *terminal);
-
 G_END_DECLS
 
 #endif //STULTO_TERMINAL_H


### PR DESCRIPTION
The window doesn't need to be responsible for resizing the terminal font. Arguably it shouldn't be; in the event that we ever inject `StultoTerminal` into another context besides `StultoMainWindow`, then we'll want the ability to resize the widget font via these same keybindings, so it makes sense for this handling to live on the widget itself.

This also means we can remove the clunky, redundant resize functions exposed to the window. The only reason those functions were added, was to allow all keybinding handling to live in one place as a temporary solution.