### PR TITLE
Support Disabling GTK Header Bar by Environment Variable

### DIFF
--- a/src/stulto-application.c
+++ b/src/stulto-application.c
@@ -30,9 +30,17 @@
 #include "stulto-exec-data.h"
 #include "stulto-main-window.h"
 
+static const gchar *HEADER_BAR_ENVAR_NAME = "STULTO_DISABLE_HEADERBAR";
+
 gboolean stulto_application_create(int argc, char *argv[]) {
     StultoAppConfig *config = g_malloc0(sizeof(StultoAppConfig));
     gchar **cmd_argv = NULL;
+
+    const gchar *use_header_bar = g_getenv(HEADER_BAR_ENVAR_NAME);
+
+    if (use_header_bar != NULL) {
+        config->disable_headerbar = TRUE;
+    }
 
     GOptionEntry options[] = {
             {


### PR DESCRIPTION
Stulto offers the ability to opt out of GTK+ CSDs. For non-GNOME users and/or X11/non-Wayland users who don't wish to use CSDs, the current implementation of this capability is a bit tedious, requiring a command-line switch to be passed for each new instance of the application.

This branch adds support for the environment variable `STULTO_DISABLE_HEADERBAR` to enable permanently disabling CSDs for Stulto environment-wide. This can be set in a session-wide configuration script (such as the user's `.bashrc` or `.xinitrc`) in order to enable running Stulto without CSDs by default.

At the moment, there is no override mechanism to re-enable CSDs except to unset the environment variable. I don't particularly see a point to adding an easier override mechanism - users will probably have a strict preference for one or the other window decorations style - but I'm open to be persuaded to revisit this later on.