### PR TITLE
Migrate Build System to Meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ stulto
 pkg
 *.pkg.tar.*
 .idea/
+
+/build

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project(
+    'stulto', 'c',
+    version: '0.1.0',
+    default_options: ['c_std=gnu99'],
+    license: ['GPL-3.0-or-later'],
+)
+
+compiler = meson.get_compiler('c')
+
+vte_dep = dependency('vte-2.91')
+
+subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,18 @@
+stulto_sources = [
+    'exit-status.c',
+    'stulto-application.c',
+    'stulto-exec-data.c',
+    'stulto-header-bar.c',
+    'stulto-main-window.c',
+    'stulto-session-manager.c',
+    'stulto-session.c',
+    'stulto-terminal-profile.c',
+    'stulto-terminal.c',
+    'stulto.c',
+]
+
+executable(
+    'stulto', stulto_sources,
+    dependencies: vte_dep,
+    install: true
+)


### PR DESCRIPTION
The migration as so far completed in this branch, was carried out with two primary goals:

* to enable a working build using Meson and Ninja
* to require as few command-line inputs as possible to enable a successful build

I haven't bothered to port the Makefile's cflags since the debug and warning level flags can be set via the Meson command line (and the values set in the Makefile likely aren't the ones you want for a production build, anyway). Meson recommends against using `-pipe`.

Note that the Makefile will likely eventually be dropped from the repo as I don't plan to support it going forward.