### PR TITLE
Drop Terminal Titlebars

### DIFF
--- a/src/stulto-header-bar.c
+++ b/src/stulto-header-bar.c
@@ -73,8 +73,6 @@ static void stulto_header_bar_finalize(GObject *object) {
 
 
 static void stulto_header_bar_init(StultoHeaderBar *header_bar) {
-    gtk_header_bar_set_has_subtitle(GTK_HEADER_BAR(header_bar), FALSE);
-
     GtkStyleContext *header_bar_style_context = gtk_widget_get_style_context(GTK_WIDGET(header_bar));
     gtk_style_context_add_class(header_bar_style_context, HEADER_BAR_STYLE_CLASS);
 

--- a/src/stulto-session-manager.c
+++ b/src/stulto-session-manager.c
@@ -187,12 +187,6 @@ gint stulto_session_manager_get_active_session_id(StultoSessionManager *session_
     return gtk_notebook_get_current_page(GTK_NOTEBOOK(session_manager));
 }
 
-void stulto_session_manager_set_active_session_id(StultoSessionManager *session_manager, gint session_id) {
-    g_return_if_fail(STULTO_IS_SESSION_MANAGER(session_manager));
-
-    gtk_notebook_set_current_page(GTK_NOTEBOOK(session_manager), session_id);
-}
-
 gint stulto_session_manager_get_n_sessions(StultoSessionManager *session_manager) {
     g_return_val_if_fail(STULTO_IS_SESSION_MANAGER(session_manager), -1);
 

--- a/src/stulto-session-manager.c
+++ b/src/stulto-session-manager.c
@@ -63,16 +63,6 @@ static void page_added_cb(GtkNotebook *notebook, GtkWidget *child, guint page_nu
     StultoSessionManager *session_manager = STULTO_SESSION_MANAGER(notebook);
     StultoSession *session = STULTO_SESSION(child);
     StultoTerminal *terminal = stulto_session_get_active_terminal(session);
-    const char *term_title = stulto_terminal_get_title(terminal);
-
-    gchar *new_title = g_strdup(
-            term_title == NULL || term_title[0] == '\0'
-            ? "Stulto"
-            : term_title);
-
-    stulto_terminal_set_title(terminal, new_title);
-
-    g_free(new_title);
 
     stulto_session_manager_set_active_session(session_manager, session);
 }

--- a/src/stulto-session-manager.h
+++ b/src/stulto-session-manager.h
@@ -36,7 +36,6 @@ StultoSession *stulto_session_manager_get_active_session(StultoSessionManager *s
 void stulto_session_manager_set_active_session(StultoSessionManager *session_manager, StultoSession *session);
 
 gint stulto_session_manager_get_active_session_id(StultoSessionManager *session_manager);
-void stulto_session_manager_set_active_session_id(StultoSessionManager *session_manager, gint session_id);
 
 gint stulto_session_manager_get_n_sessions(StultoSessionManager *session_manager);
 

--- a/src/stulto-session.c
+++ b/src/stulto-session.c
@@ -44,17 +44,11 @@ static void stulto_session_finalize(GObject *object);
 static void stulto_session_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
 static void stulto_session_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
 
-static void stulto_session_class_init(StultoSessionClass *klass);
-static void stulto_session_init(StultoSession *session);
-
 StultoSession *stulto_session_new(StultoTerminal *terminal);
 
 /* Getters & setters */
 StultoTerminal *stulto_session_get_active_terminal(StultoSession *session);
 void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *terminal);
-
-gint stulto_session_get_active_terminal_id(StultoSession *session);
-void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id);
 
 // endregion
 
@@ -143,15 +137,6 @@ void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *
     session->active_terminal = terminal;
 
     gtk_container_add(GTK_CONTAINER(session), GTK_WIDGET(terminal));
-}
-
-gint stulto_session_get_active_terminal_id(StultoSession *session) {
-    // TODO - un-stub
-    return 0;
-}
-
-void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id) {
-    // TODO - un-stub
 }
 
 // endregion

--- a/src/stulto-session.h
+++ b/src/stulto-session.h
@@ -38,9 +38,6 @@ StultoSession *stulto_session_new(StultoTerminal *terminal);
 StultoTerminal *stulto_session_get_active_terminal(StultoSession *session);
 void stulto_session_set_active_terminal(StultoSession *session, StultoTerminal *terminal);
 
-gint stulto_session_get_active_terminal_id(StultoSession *session);
-void stulto_session_set_active_terminal_id(StultoSession *session, gint terminal_id);
-
 G_END_DECLS
 
 #endif //STULTO_SESSION_H

--- a/src/stulto-terminal.c
+++ b/src/stulto-terminal.c
@@ -75,12 +75,6 @@ void stulto_terminal_set_title(StultoTerminal *terminal, gchar *title);
 static void vte_window_title_changed_cb(VteTerminal *terminal_widget, gpointer data) {
     GtkWidget *parent = gtk_widget_get_ancestor(GTK_WIDGET(terminal_widget), STULTO_TYPE_TERMINAL);
 
-    const gchar *vte_title = vte_terminal_get_window_title(terminal_widget);
-
-    gchar *new_title = g_strdup(vte_title);
-
-    stulto_terminal_set_title(STULTO_TERMINAL(parent), new_title);
-
     g_object_notify(G_OBJECT(parent), "title");
 }
 
@@ -389,24 +383,12 @@ static void stulto_terminal_class_init(StultoTerminalClass *klass) {
 static void stulto_terminal_init(StultoTerminal *terminal) {
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-    GtkWidget *titlebar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    // TODO - need to ship a default stylesheet to ensure that terminal titlebars aren't transparent
-    // This makes the app look broken
-    GtkStyleContext *box_style_context = gtk_widget_get_style_context(titlebar);
-    gtk_style_context_add_class(box_style_context, STULTO_TERMINAL_TITLEBAR_STYLE_CLASS);
-
-    GtkWidget *label = gtk_label_new("Stulto");
-    gtk_container_add(GTK_CONTAINER(titlebar), label);
-
-    gtk_box_pack_start(GTK_BOX(box), titlebar, FALSE, FALSE, 0);
-
     GtkWidget *terminal_widget = vte_terminal_new();
     gtk_box_pack_start(GTK_BOX(box), terminal_widget, TRUE, TRUE, 0);
 
     gtk_container_add(GTK_CONTAINER(terminal), box);
 
     terminal->terminal_widget = VTE_TERMINAL(terminal_widget);
-    terminal->title_widget = GTK_LABEL(label);
 }
 
 StultoTerminal *stulto_terminal_new(StultoTerminalProfile *profile, StultoExecData *exec_data) {


### PR DESCRIPTION
At one point, I had ambitions to implement Tilix-style terminal tiling in Stulto, and I intended to borrow many ideas from its own UI to accomplish this. (Cf. the headerbar buttons for another obvious example.)

At this point, my opinions on terminal interfaces have shifted, along with my priorities and capacity. Stulto is already very light on UI, and the intention is to keep it that way; features like tiling require a certain amount of signposting and flexibility to make them work well, and the approach I had in mind for Stulto would essentially just remove those bits of the experience. As such, I think that Tilix is currently best-in-class for its use case, and Stulto as a Tilix-lite would probably be more frustrating than fun to use. Anyone who wishes to use a tiled terminal app should use Tilix; anyone who wishes to craft an even better tiled terminal app should contribute to Tilix.

Since I'm no longer working towards implementing a Tilix-like UX in Stulto, I'm also dropping the components that were developed to facilitate this feature, such as the terminal titlebars. Without tiling, these widgets are arguably redundant, and they eat up window real estate.

The next several merges will include a deeper refactor of the code to remove the session model components that were factored out to make room for tiles. From a user perspective, very little if anything should change, but in the unlikely event that folks are leveraging the GObject hierarchy in Stulto, significant breaking changes are on the horizon.

For most folks who prefer as simplistic an interface as Stulto offers but are looking for something like a tiled experience, you'll probably find yourself at home running tmux in a Stulto tab.